### PR TITLE
Use url path instead of query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ server := &viewproxy.Server{
 // Define a route with a :name parameter that will be forwarded to the target host.
 // This will make 3 fragment requests, one for the header, hello, and footer.
 server.Get("/hello/:name", []string{
-	"header", // GET http://localhost:3000/_view_fragments?fragment=header&name=world
-	"hello",  // GET http://localhost:3000/_view_fragments?fragment=hello&name=world
-	"footer", // GET http://localhost:3000/_view_fragments?fragment=footer&name=world
+	"header", // GET http://localhost:3000/_view_fragments/header?name=world
+	"hello",  // GET http://localhost:3000/_view_fragments/hello?name=world
+	"footer", // GET http://localhost:3000/_view_fragments/footer?name=world
 })
 
 server.ListenAndServe()

--- a/server.go
+++ b/server.go
@@ -87,7 +87,10 @@ func (s *Server) ListenAndServe() error {
 }
 
 func (s *Server) constructFragmentUrl(fragment string, parameters map[string]string) string {
-	targetUrl, err := url.Parse(s.Target)
+	targetUrl, err := url.Parse(
+		fmt.Sprintf("%s/%s", s.Target, fragment),
+	)
+
 	if err != nil {
 		panic(err)
 	}
@@ -97,7 +100,6 @@ func (s *Server) constructFragmentUrl(fragment string, parameters map[string]str
 	for name, value := range parameters {
 		query.Add(name, value)
 	}
-	query.Add("fragment", fragment)
 
 	targetUrl.RawQuery = query.Encode()
 

--- a/server_test.go
+++ b/server_test.go
@@ -13,15 +13,14 @@ import (
 func TestBasicServer(t *testing.T) {
 	instance := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
-		fragment := params.Get("fragment")
 
 		w.WriteHeader(http.StatusOK)
 
-		if fragment == "header" {
+		if r.URL.Path == "/header" {
 			w.Write([]byte("<body>"))
-		} else if fragment == "body" {
+		} else if r.URL.Path == "/body" {
 			w.Write([]byte(fmt.Sprintf("hello %s", params.Get("name"))))
-		} else if fragment == "footer" {
+		} else if r.URL.Path == "/footer" {
 			w.Write([]byte("</body>"))
 		}
 	})


### PR DESCRIPTION
Currently the fragment name is passed via query param. e.g.  `header`
would be `?fragment=header`.

This removes the query param in favor of extending the target url,
creating a unique url for each fragment.

e.g. the `site/header` fragment with a target of
`https://localhost:3000/_view_fragments` would result in a request to
`htttps://localhost:3000/_view_fragments/site/header`

This aligns the behavior of fragments with the behavior of layouts.
