### PR TITLE
Add ability to define routes via JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 view-proxy
 log
-demo
+./demo

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -12,10 +12,10 @@ import (
 
 func main() {
 	server := &viewproxy.Server{
-		Port:         getPort(),
-		ProxyTimeout: time.Duration(5) * time.Second,
-		Target:       getTarget(),
-		Logger:       buildLogger(),
+		Port:             getPort(),
+		ProxyTimeout:     time.Duration(5) * time.Second,
+		Target:           getTarget(),
+		Logger:           buildLogger(),
 		DefaultPageTitle: "Demo App",
 	}
 

--- a/config.go
+++ b/config.go
@@ -1,0 +1,37 @@
+package viewproxy
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+type configRouteEntry struct {
+	Url               string   `json:"url"`
+	LayoutFragmentUrl string   `json:"layout"`
+	FragmentUrls      []string `json:"fragments"`
+}
+
+func readConfigFile(filePath string) ([]configRouteEntry, error) {
+	file, err := os.Open(filePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	routesJson, err := ioutil.ReadAll(file)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var routeEntries []configRouteEntry
+
+	err = json.Unmarshal(routesJson, &routeEntries)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return routeEntries, nil
+}

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -15,7 +15,7 @@ var defaultTimeout = time.Duration(5) * time.Second
 func TestFetchReturnsMultipleResults(t *testing.T) {
 	server := startServer()
 
-	urls := []string{"http://localhost:9999?fragment=header", "http://localhost:9999?fragment=footer"}
+	urls := []string{"http://localhost:9990?fragment=header", "http://localhost:9990?fragment=footer"}
 	results, err := Fetch(context.TODO(), urls, defaultTimeout)
 
 	assert.Nil(t, err)
@@ -38,11 +38,11 @@ func TestFetchReturnsMultipleResults(t *testing.T) {
 func Test404ReturnsError(t *testing.T) {
 	server := startServer()
 
-	urls := []string{"http://localhost:9999/wowomg"}
+	urls := []string{"http://localhost:9990/wowomg"}
 	results, err := Fetch(context.TODO(), urls, defaultTimeout)
 
 	assert.ErrorIs(t, err, NotFoundErr)
-	assert.EqualError(t, err, "URL http://localhost:9999/wowomg: Not found")
+	assert.EqualError(t, err, "URL http://localhost:9990/wowomg: Not found")
 	assert.Equal(t, 0, len(results), "Expected 0 results")
 
 	server.Close()
@@ -52,7 +52,7 @@ func Test500ReturnsError(t *testing.T) {
 	server := startServer()
 	start := time.Now()
 
-	urls := []string{"http://localhost:9999/?fragment=oops", "http://localhost:9999?fragment=slow"}
+	urls := []string{"http://localhost:9990/?fragment=oops", "http://localhost:9990?fragment=slow"}
 	ctx := context.Background()
 	results, err := Fetch(ctx, urls, defaultTimeout)
 
@@ -60,7 +60,7 @@ func Test500ReturnsError(t *testing.T) {
 
 	assert.Less(t, duration, time.Duration(3)*time.Second)
 	assert.ErrorIs(t, err, Non2xxErr)
-	assert.EqualError(t, err, "Status 500 for URL http://localhost:9999/?fragment=oops: Status code not in 2xx range")
+	assert.EqualError(t, err, "Status 500 for URL http://localhost:9990/?fragment=oops: Status code not in 2xx range")
 	assert.Equal(t, 0, len(results), "Expected 0 results")
 
 	server.Close()
@@ -70,7 +70,7 @@ func TestTimeout(t *testing.T) {
 	server := startServer()
 	start := time.Now()
 
-	urls := []string{"http://localhost:9999?fragment=slow"}
+	urls := []string{"http://localhost:9990?fragment=slow"}
 	_, err := Fetch(context.Background(), urls, time.Duration(100)*time.Millisecond)
 	duration := time.Since(start)
 
@@ -103,7 +103,7 @@ func startServer() *http.Server {
 		}
 	})
 
-	testServer := &http.Server{Addr: ":9999", Handler: instance}
+	testServer := &http.Server{Addr: ":9990", Handler: instance}
 	go func() {
 		if err := testServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			panic(err)

--- a/server_test.go
+++ b/server_test.go
@@ -7,17 +7,98 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 )
 
+func TestMain(m *testing.M) {
+	targetServer := startTargetServer()
+	result := m.Run()
+	targetServer.Shutdown(context.TODO())
+	os.Exit(result)
+}
+
 func TestBasicServer(t *testing.T) {
+	viewProxyServer := &Server{
+		Port:         9998,
+		Target:       "http://localhost:9994",
+		Logger:       log.New(ioutil.Discard, "", log.Ldate|log.Ltime),
+		ProxyTimeout: time.Duration(5) * time.Second,
+	}
+
+	viewProxyServer.IgnoreHeader("etag")
+	viewProxyServer.Get("/hello/:name", "/layouts/test_layout", []string{"header", "body", "footer"})
+
+	go func() {
+		if err := viewProxyServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			panic(err)
+		}
+	}()
+	defer viewProxyServer.Shutdown(context.TODO())
+
+	resp, err := http.Get("http://localhost:9998/hello/world")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	expected := "<html><body>hello world</body></html>"
+
+	assert.Equal(t, expected, string(body))
+	assert.Equal(t, "viewproxy", resp.Header.Get("x-name"), "Expected response to have an X-Name header")
+	assert.Equal(t, "", resp.Header.Get("etag"), "Expexted response to have removed etag header")
+}
+
+func TestServerFromConfig(t *testing.T) {
+	file, err := ioutil.TempFile(os.TempDir(), "config.json")
+	defer os.Remove(file.Name())
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	file.Write([]byte(`[{
+		"url": "/hello/:name",
+		"layout": "/layouts/test_layout",
+		"fragments": ["header", "body", "footer"]
+	}]`))
+
+	file.Close()
+
+	viewProxyServer := &Server{
+		Port:         9998,
+		Target:       "http://localhost:9994",
+		Logger:       log.New(ioutil.Discard, "", log.Ldate|log.Ltime),
+		ProxyTimeout: time.Duration(5) * time.Second,
+	}
+
+	viewProxyServer.LoadRouteConfig(file.Name())
+	go func() {
+		if err := viewProxyServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			panic(err)
+		}
+	}()
+
+	resp, err := http.Get("http://localhost:9998/hello/world")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	expected := "<html><body>hello world</body></html>"
+
+	assert.Equal(t, expected, string(body))
+}
+
+func startTargetServer() *http.Server {
 	instance := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
 
 		w.Header().Set("EtAg", "1234")
 		w.Header().Set("X-Name", "viewproxy")
-
 		w.WriteHeader(http.StatusOK)
 
 		if r.URL.Path == "/layouts/test_layout" {
@@ -38,36 +119,5 @@ func TestBasicServer(t *testing.T) {
 		}
 	}()
 
-	viewProxyServer := &Server{
-		Port:         9998,
-		Target:       "http://localhost:9994",
-		Logger:       log.New(ioutil.Discard, "", log.Ldate|log.Ltime),
-		ProxyTimeout: time.Duration(5) * time.Second,
-	}
-
-	viewProxyServer.IgnoreHeader("etag")
-	viewProxyServer.Get("/hello/:name", "test_layout", []string{"header", "body", "footer"})
-
-	go func() {
-		if err := viewProxyServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			panic(err)
-		}
-	}()
-
-	resp, err := http.Get("http://localhost:9998/hello/world")
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	expected := "<html><body>hello world</body></html>"
-
-	assert.Equal(t, expected, string(body))
-
-	assert.Equal(t, "viewproxy", resp.Header.Get("x-name"), "Expected response to have an X-Name header")
-	assert.Equal(t, "", resp.Header.Get("etag"), "Expexted response to have removed etag header")
-
-	testServer.Shutdown(context.TODO())
-	viewProxyServer.Shutdown(context.TODO())
+	return testServer
 }


### PR DESCRIPTION
This defines a JSON format that can be used to import routes into a
viewproxy server instead of having to define them manually. This is
meant to be used with a lightweight Rails DSL to define pages and their
fragments so viewproxy routes can be auto-generated.
