### PR TITLE
Add basic header forwarding

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -19,6 +19,7 @@ func main() {
 		DefaultPageTitle: "Demo App",
 	}
 
+	server.IgnoreHeader("etag")
 	server.Get("/hello/:name", "my_layout", []string{
 		"header",
 		"hello",


### PR DESCRIPTION
This adds basic header forwarding from the layout request to the voltron
response. So any headers set in the request made to the layout that
aren't in the ignore list will be sent as part of the response.

As a default, the ignored headers only contains `content-length`.
