### PR TITLE
Add philosophy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# View-Proxy
+# viewproxy
 
-View-Proxy is a Go service that makes multiple requests to an application in parallel, fetching HTML content and stitching it together to serve to a user.
+`viewproxy` is a Go service that makes multiple requests to an application in parallel, fetching HTML content and stitching it together to serve to a user.
 
 This is alpha software, and is currently a proof of concept used in conjunction with Rails and View Component as a performance optimization.
 
@@ -8,16 +8,16 @@ This is alpha software, and is currently a proof of concept used in conjunction 
 
 See `cmd/demo/main.go` for an example of how to use the package.
 
-To use view-proxy:
+To use `viewproxy`:
 
 ```go
-import "github.com/blakewilliams/view-proxy"
+import "github.com/blakewilliams/viewproxy"
 
 // Create a new Server Instance
 server := &viewproxy.Server{
 	Port:         3005,
 	ProxyTimeout: time.Duration(5)*time.Second,
-	// View-Proxy will hit this URL, forwarding named URL parameters as query params.
+	// viewproxy will hit this URL, forwarding named URL parameters as query params.
 	// The `fragment` query param is the name of the requested fragment to render.
 	Target:       "http://localhost:3000/_view_fragments",
 	Logger:       log.Default,
@@ -41,15 +41,14 @@ server.ListenAndServe()
 - The port the server is bound to `3005` by default but can be set via the `PORT` environment variable.
 - The target server can be set via the `TARGET` environment variable.
   - The default is `localhost:3000/_view_fragments`
-  - View-Proxy will call that end-point with the fragment name being passed as a query parameter. e.g. `localhost:3000/_view_fragments?fragment=header`
+  - `viewproxy` will call that end-point with the fragment name being passed as a query parameter. e.g. `localhost:3000/_view_fragments?fragment=header`
 
-To run view-proxy, run `go build ./cmd/demo && ./demo`
+To run `viewproxy`, run `go build ./cmd/demo && ./demo`
 
-## To-Do
+## Philosophy
 
-- [x] Add logging
-- [ ] Come up with a solution for query param forwarding
-- [x] Add tests for the core workflows
-- [x] Follow a better application structure (`cmd` directory, `pkg` directory, etc)
-- [ ] Add support for handling errors
-- [ ] Copy headers (especially for content-type) from the first request and re-use them for the response
+`viewproxy` is a simple service designed to sit between a browser request and a web application. It is used to break pages down into fragments that can be rendered in parallel for faster response times.
+
+- `viewproxy` is not coupled to a specific application framework, but *is* being driven by close integration with Rails applications.  
+- `viewproxy` should rely on Rails' (or other target application framework) strengths when possible.
+- `viewproxy` itself and its client API's should focus on developer happiness and productivity.


### PR DESCRIPTION
This also fixes the spelling of `viewproxy` in places.
