### PR TITLE
Add proxy pass through functionality for GET requests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Build
       run: go build -v ./...

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -11,15 +11,14 @@ import (
 )
 
 func main() {
-	server := &viewproxy.Server{
-		Port:             getPort(),
-		ProxyTimeout:     time.Duration(5) * time.Second,
-		Target:           getTarget(),
-		Logger:           buildLogger(),
-		DefaultPageTitle: "Demo App",
-	}
-
+	target := getTarget()
+	server := viewproxy.NewServer(target)
+	server.Port = getPort()
+	server.ProxyTimeout = time.Duration(5) * time.Second
+	server.Logger = buildLogger()
+	server.DefaultPageTitle = "Demo app"
 	server.IgnoreHeader("etag")
+
 	server.Get("/hello/:name", "my_layout", []string{
 		"header",
 		"hello",

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -18,6 +18,7 @@ func main() {
 	server.Logger = buildLogger()
 	server.DefaultPageTitle = "Demo app"
 	server.IgnoreHeader("etag")
+	server.PassThrough = true
 
 	server.Get("/hello/:name", "my_layout", []string{
 		"header",

--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -70,7 +70,7 @@ func indexOfResult(urls []string, result *Result) int {
 	return -1
 }
 
-func FetchUrlWithoutStatusCodeCheck(ctx context.Context, url string, headers http.Header) (*Result, error) {
+func fetchUrlWithoutStatusCodeCheck(ctx context.Context, url string, headers http.Header) (*Result, error) {
 	start := time.Now()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
@@ -107,7 +107,7 @@ func FetchUrlWithoutStatusCodeCheck(ctx context.Context, url string, headers htt
 }
 
 func FetchUrl(ctx context.Context, url string, headers http.Header) (*Result, error) {
-	result, err := FetchUrlWithoutStatusCodeCheck(ctx, url, headers)
+	result, err := fetchUrlWithoutStatusCodeCheck(ctx, url, headers)
 
 	if err != nil {
 		return nil, err

--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -2,7 +2,6 @@ package multiplexer
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -10,17 +9,6 @@ import (
 	"sync"
 	"time"
 )
-
-var NotFoundErr = errors.New("Not found")
-var Non2xxErr = errors.New("Status code not in 2xx range")
-
-type Result struct {
-	Url          string
-	Duration     time.Duration
-	HttpResponse *http.Response
-	Body         []byte
-	StatusCode   int
-}
 
 func Fetch(ctx context.Context, urls []string, headers http.Header, timeout time.Duration) ([]*Result, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -101,7 +101,7 @@ func TestFetchWithoutStatusCodeCheckIgnoresStatuses(t *testing.T) {
 	server := startServer()
 
 	ctx := context.Background()
-	results, err := FetchUrlWithoutStatusCodeCheck(ctx, "http://localhost:9990/?fragment=oops", http.Header{})
+	results, err := fetchUrlWithoutStatusCodeCheck(ctx, "http://localhost:9990/?fragment=oops", http.Header{})
 
 	assert.Nil(t, err)
 	assert.Equal(t, 500, results.StatusCode)

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -46,7 +46,6 @@ func TestFetchForwardsHeaders(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	fmt.Println(string(results[0].Body))
 	assert.Contains(t, string(results[0].Body), "X-Name:viewproxy", "Expected X-Name header to be present")
 
 	server.Close()

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -16,7 +16,7 @@ func TestFetchReturnsMultipleResults(t *testing.T) {
 	server := startServer()
 
 	urls := []string{"http://localhost:9990?fragment=header", "http://localhost:9990?fragment=footer"}
-	results, err := Fetch(context.TODO(), urls, defaultTimeout)
+	results, err := Fetch(context.TODO(), urls, http.Header{}, defaultTimeout)
 
 	assert.Nil(t, err)
 
@@ -35,11 +35,28 @@ func TestFetchReturnsMultipleResults(t *testing.T) {
 	server.Close()
 }
 
-func Test404ReturnsError(t *testing.T) {
+func TestFetchForwardsHeaders(t *testing.T) {
+	server := startServer()
+	headers := map[string][]string{
+		"X-Name": []string{"viewproxy"},
+	}
+
+	urls := []string{"http://localhost:9990?fragment=echo_headers"}
+	results, err := Fetch(context.TODO(), urls, headers, defaultTimeout)
+
+	assert.Nil(t, err)
+
+	fmt.Println(string(results[0].Body))
+	assert.Contains(t, string(results[0].Body), "X-Name:viewproxy", "Expected X-Name header to be present")
+
+	server.Close()
+}
+
+func TestFetch404ReturnsError(t *testing.T) {
 	server := startServer()
 
 	urls := []string{"http://localhost:9990/wowomg"}
-	results, err := Fetch(context.TODO(), urls, defaultTimeout)
+	results, err := Fetch(context.TODO(), urls, http.Header{}, defaultTimeout)
 
 	assert.ErrorIs(t, err, NotFoundErr)
 	assert.EqualError(t, err, "URL http://localhost:9990/wowomg: Not found")
@@ -48,13 +65,13 @@ func Test404ReturnsError(t *testing.T) {
 	server.Close()
 }
 
-func Test500ReturnsError(t *testing.T) {
+func TestFetch500ReturnsError(t *testing.T) {
 	server := startServer()
 	start := time.Now()
 
 	urls := []string{"http://localhost:9990/?fragment=oops", "http://localhost:9990?fragment=slow"}
 	ctx := context.Background()
-	results, err := Fetch(ctx, urls, defaultTimeout)
+	results, err := Fetch(ctx, urls, http.Header{}, defaultTimeout)
 
 	duration := time.Since(start)
 
@@ -66,16 +83,28 @@ func Test500ReturnsError(t *testing.T) {
 	server.Close()
 }
 
-func TestTimeout(t *testing.T) {
+func TestFetchTimeout(t *testing.T) {
 	server := startServer()
 	start := time.Now()
 
 	urls := []string{"http://localhost:9990?fragment=slow"}
-	_, err := Fetch(context.Background(), urls, time.Duration(100)*time.Millisecond)
+	_, err := Fetch(context.Background(), urls, http.Header{}, time.Duration(100)*time.Millisecond)
 	duration := time.Since(start)
 
 	assert.EqualError(t, err, "context deadline exceeded")
 	assert.Less(t, duration, time.Duration(120)*time.Millisecond)
+
+	server.Close()
+}
+
+func TestFetchWithoutStatusCodeCheckIgnoresStatuses(t *testing.T) {
+	server := startServer()
+
+	ctx := context.Background()
+	results, err := FetchUrlWithoutStatusCodeCheck(ctx, "http://localhost:9990/?fragment=oops", http.Header{})
+
+	assert.Nil(t, err)
+	assert.Equal(t, 500, results.StatusCode)
 
 	server.Close()
 }
@@ -97,6 +126,14 @@ func startServer() *http.Server {
 		} else if fragment == "oops" {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte("500"))
+		} else if fragment == "echo_headers" {
+			for name, values := range r.Header {
+				for _, value := range values {
+					w.Write(
+						[]byte(fmt.Sprintf("%s:%s\n", name, value)),
+					)
+				}
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte("Not found"))

--- a/pkg/multiplexer/proxy.go
+++ b/pkg/multiplexer/proxy.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 )
 
+// Hop-by-hop headers defined here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
 var HopByHopHeaders []string = []string{
 	"Connection",
 	"Keep-Alive",

--- a/pkg/multiplexer/proxy.go
+++ b/pkg/multiplexer/proxy.go
@@ -1,0 +1,63 @@
+package multiplexer
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+var HopByHopHeaders []string = []string{
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"TE",
+	"Trailers",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+func ProxyRequest(ctx context.Context, targetUrl string, req *http.Request) (*Result, error) {
+	headers := generateProxyRequestHeaders(req.Header)
+
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if val := headers.Get("X-Forwarded-For"); val != "" {
+		newHeader := fmt.Sprintf("%s,%s", val, host)
+		headers.Set("X-Forwarded-For", newHeader)
+	} else {
+		headers.Set("X-Forwarded-For", host)
+	}
+
+	headers.Set("X-Forwarded-Proto", req.Proto)
+
+	// TODO handle timeouts or maybe rely on target?
+	result, err := fetchUrlWithoutStatusCodeCheck(context.TODO(), targetUrl, headers)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func generateProxyRequestHeaders(headers http.Header) http.Header {
+	newHeaders := make(http.Header)
+
+	// TODO remove headers listed in the Connection header
+
+	for name, values := range headers {
+		newHeaders[name] = values
+	}
+
+	for _, hopByHopHeader := range HopByHopHeaders {
+		newHeaders.Del(hopByHopHeader)
+	}
+
+	return newHeaders
+}

--- a/pkg/multiplexer/proxy_test.go
+++ b/pkg/multiplexer/proxy_test.go
@@ -1,0 +1,37 @@
+package multiplexer
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProxyRequest(t *testing.T) {
+	done := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(done)
+
+		assert.Equal(t, "", r.Header.Get("Keep-Alive"), "Expected Keep-Alive to be filtered")
+		assert.Equal(t, "0.0.0.0", r.Header.Get("X-Forwarded-For"))
+	}))
+
+	headers := make(http.Header)
+	headers.Set("Keep-Alive", "1000")
+
+	fakeReq := http.Request{
+		RemoteAddr: "0.0.0.0:3005",
+		Header:     headers,
+	}
+
+	result, err := ProxyRequest(context.TODO(), server.URL, &fakeReq)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "", result.Header().Get("Keep-Alive"), "Expected Keep-Alive to be filtered")
+
+	select {
+	case <-done:
+		server.Close()
+	}
+}

--- a/pkg/multiplexer/result.go
+++ b/pkg/multiplexer/result.go
@@ -1,0 +1,36 @@
+package multiplexer
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+var NotFoundErr = errors.New("Not found")
+var Non2xxErr = errors.New("Status code not in 2xx range")
+
+type Result struct {
+	Url          string
+	Duration     time.Duration
+	HttpResponse *http.Response
+	Body         []byte
+	StatusCode   int
+}
+
+func (r *Result) Header() http.Header {
+	return r.HttpResponse.Header
+}
+
+func (r *Result) HeadersWithoutProxyHeaders() http.Header {
+	headers := make(http.Header)
+
+	for name, values := range r.Header() {
+		headers[name] = values
+	}
+
+	for _, hopByHopHeader := range HopByHopHeaders {
+		headers.Del(hopByHopHeader)
+	}
+
+	return headers
+}

--- a/server.go
+++ b/server.go
@@ -67,6 +67,10 @@ func (s *Server) Shutdown(ctx context.Context) {
 	s.httpServer.Shutdown(ctx)
 }
 
+func (s *Server) Close() {
+	s.httpServer.Close()
+}
+
 // TODO this should probably be a tree structure for faster lookups
 func (s *Server) matchingRoute(path string) (*Route, map[string]string) {
 	parts := strings.Split(path, "/")

--- a/server.go
+++ b/server.go
@@ -134,7 +134,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Write(outputHtml)
 	} else if s.PassThrough {
 		targetUrl, err := url.Parse(
-			fmt.Sprintf("%s/%s", s.Target, r.URL.String()),
+			fmt.Sprintf("%s/%s", strings.TrimRight(s.Target, "/"), strings.TrimLeft(r.URL.String(), "/")),
 		)
 
 		if err != nil {
@@ -187,12 +187,14 @@ func (s *Server) ListenAndServe() error {
 }
 
 func (s *Server) constructLayoutUrl(layout string, parameters map[string]string) string {
-	targetUrl, err := url.Parse(s.Target)
+	targetUrl, err := url.Parse(
+		fmt.Sprintf("%s/%s", strings.TrimRight(s.Target, "/"), strings.TrimLeft(layout, "/")),
+	)
+
+	// TODO this should not panic
 	if err != nil {
 		panic(err)
 	}
-
-	targetUrl.Path = targetUrl.Path + layout
 
 	query := url.Values{}
 
@@ -207,7 +209,7 @@ func (s *Server) constructLayoutUrl(layout string, parameters map[string]string)
 
 func (s *Server) constructFragmentUrl(fragment string, parameters map[string]string) string {
 	targetUrl, err := url.Parse(
-		fmt.Sprintf("%s/%s", s.Target, fragment),
+		fmt.Sprintf("%s/%s", strings.TrimRight(s.Target, "/"), strings.TrimLeft(fragment, "/")),
 	)
 
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -151,6 +151,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		w.WriteHeader(result.StatusCode)
 		w.Write(result.Body)
+
+		s.Logger.Printf("Proxied %s in %v", result.Url, result.Duration)
 	} else {
 		s.Logger.Printf("Rendering 404 for %s\n", r.URL.Path)
 		w.WriteHeader(404)

--- a/server.go
+++ b/server.go
@@ -26,16 +26,24 @@ type Server struct {
 
 var setMember struct{}
 
+func NewServer(target string) *Server {
+	return &Server{
+		DefaultPageTitle: "viewproxy",
+		Logger:           log.Default(),
+		Port:             3005,
+		ProxyTimeout:     time.Duration(10) * time.Second,
+		Target:           target,
+		ignoreHeaders:    make(map[string]struct{}, 0),
+		routes:           make([]Route, 0),
+	}
+}
+
 func (s *Server) Get(path string, layout string, fragments []string) {
 	route := newRoute(path, layout, fragments)
 	s.routes = append(s.routes, *route)
 }
 
 func (s *Server) IgnoreHeader(name string) {
-	if s.ignoreHeaders == nil {
-		s.ignoreHeaders = make(map[string]struct{}, 0)
-	}
-
 	s.ignoreHeaders[strings.ToLower(name)] = setMember
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -11,14 +11,10 @@ import (
 	"testing"
 )
 
-func TestMain(m *testing.M) {
-	targetServer := startTargetServer()
-	result := m.Run()
-	targetServer.Shutdown(context.TODO())
-	os.Exit(result)
-}
-
 func TestBasicServer(t *testing.T) {
+	targetServer := startTargetServer()
+	defer targetServer.Shutdown(context.TODO())
+
 	viewProxyServer := NewServer("http://localhost:9994")
 	viewProxyServer.Port = 9998
 	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
@@ -48,12 +44,14 @@ func TestBasicServer(t *testing.T) {
 }
 
 func TestServerFromConfig(t *testing.T) {
-	file, err := ioutil.TempFile(os.TempDir(), "config.json")
-	defer os.Remove(file.Name())
+	targetServer := startTargetServer()
+	defer targetServer.Shutdown(context.TODO())
 
+	file, err := ioutil.TempFile(os.TempDir(), "config.json")
 	if err != nil {
 		t.Error(err)
 	}
+	defer os.Remove(file.Name())
 
 	file.Write([]byte(`[{
 		"url": "/hello/:name",
@@ -86,22 +84,82 @@ func TestServerFromConfig(t *testing.T) {
 	assert.Equal(t, expected, string(body))
 }
 
+func TestPassThroughEnabled(t *testing.T) {
+	targetServer := startTargetServer()
+	defer targetServer.Shutdown(context.TODO())
+
+	viewProxyServer := NewServer("http://localhost:9994")
+	viewProxyServer.Port = 9995
+	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
+	viewProxyServer.PassThrough = true
+
+	go func() {
+		if err := viewProxyServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			panic(err)
+		}
+	}()
+
+	resp, err := http.Get("http://localhost:9995/hello/world")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+
+	assert.Equal(t, 404, resp.StatusCode)
+	assert.Equal(t, "target: 404 not found", string(body))
+}
+
+func TestPassThroughDisabled(t *testing.T) {
+	targetServer := startTargetServer()
+	defer targetServer.Shutdown(context.TODO())
+
+	viewProxyServer := NewServer("http://localhost:9994")
+	viewProxyServer.Port = 9993
+	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
+	viewProxyServer.PassThrough = false
+
+	go func() {
+		if err := viewProxyServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			panic(err)
+		}
+	}()
+
+	resp, err := http.Get("http://localhost:9993/hello/world")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+
+	assert.Equal(t, 404, resp.StatusCode)
+	assert.Equal(t, "404 not found", string(body))
+}
+
 func startTargetServer() *http.Server {
 	instance := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
 
 		w.Header().Set("EtAg", "1234")
 		w.Header().Set("X-Name", "viewproxy")
-		w.WriteHeader(http.StatusOK)
 
 		if r.URL.Path == "/layouts/test_layout" {
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("<html>{{{VIEW_PROXY_CONTENT}}}</html>"))
 		} else if r.URL.Path == "/header" {
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("<body>"))
 		} else if r.URL.Path == "/body" {
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(fmt.Sprintf("hello %s", params.Get("name"))))
 		} else if r.URL.Path == "/footer" {
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("</body>"))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte("target: 404 not found"))
 		}
 	})
 

--- a/server_test.go
+++ b/server_test.go
@@ -101,7 +101,7 @@ func TestPassThroughEnabled(t *testing.T) {
 	}()
 	defer viewProxyServer.Close()
 
-	resp, err := http.Get("http://localhost:9995/hello/world")
+	resp, err := http.Get("http://localhost:9995/oops")
 
 	if err != nil {
 		t.Fatal(err)
@@ -109,8 +109,8 @@ func TestPassThroughEnabled(t *testing.T) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 
-	assert.Equal(t, 404, resp.StatusCode)
-	assert.Equal(t, "target: 404 not found", string(body))
+	assert.Equal(t, 500, resp.StatusCode)
+	assert.Equal(t, "Something went wrong", string(body))
 }
 
 func TestPassThroughDisabled(t *testing.T) {
@@ -160,6 +160,9 @@ func startTargetServer() *http.Server {
 		} else if r.URL.Path == "/footer" {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("</body>"))
+		} else if r.URL.Path == "/oops" {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Something went wrong"))
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte("target: 404 not found"))

--- a/server_test.go
+++ b/server_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestMain(m *testing.M) {
@@ -20,12 +19,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestBasicServer(t *testing.T) {
-	viewProxyServer := &Server{
-		Port:         9998,
-		Target:       "http://localhost:9994",
-		Logger:       log.New(ioutil.Discard, "", log.Ldate|log.Ltime),
-		ProxyTimeout: time.Duration(5) * time.Second,
-	}
+	viewProxyServer := NewServer("http://localhost:9994")
+	viewProxyServer.Port = 9998
+	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
 
 	viewProxyServer.IgnoreHeader("etag")
 	viewProxyServer.Get("/hello/:name", "/layouts/test_layout", []string{"header", "body", "footer"})
@@ -67,12 +63,9 @@ func TestServerFromConfig(t *testing.T) {
 
 	file.Close()
 
-	viewProxyServer := &Server{
-		Port:         9998,
-		Target:       "http://localhost:9994",
-		Logger:       log.New(ioutil.Discard, "", log.Ldate|log.Ltime),
-		ProxyTimeout: time.Duration(5) * time.Second,
-	}
+	viewProxyServer := NewServer("http://localhost:9994")
+	viewProxyServer.Port = 9998
+	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
 
 	viewProxyServer.LoadRouteConfig(file.Name())
 	go func() {

--- a/server_test.go
+++ b/server_test.go
@@ -27,7 +27,7 @@ func TestBasicServer(t *testing.T) {
 			panic(err)
 		}
 	}()
-	defer viewProxyServer.Shutdown(context.TODO())
+	defer viewProxyServer.Close()
 
 	resp, err := http.Get("http://localhost:9998/hello/world")
 
@@ -71,6 +71,7 @@ func TestServerFromConfig(t *testing.T) {
 			panic(err)
 		}
 	}()
+	defer viewProxyServer.Close()
 
 	resp, err := http.Get("http://localhost:9998/hello/world")
 
@@ -98,6 +99,7 @@ func TestPassThroughEnabled(t *testing.T) {
 			panic(err)
 		}
 	}()
+	defer viewProxyServer.Close()
 
 	resp, err := http.Get("http://localhost:9995/hello/world")
 
@@ -125,6 +127,7 @@ func TestPassThroughDisabled(t *testing.T) {
 			panic(err)
 		}
 	}()
+	defer viewProxyServer.Close()
 
 	resp, err := http.Get("http://localhost:9993/hello/world")
 


### PR DESCRIPTION
This adds a new value to the Server struct, `PassThrough`, which when
set to true, will forward a request as-received to the target server and
proxy the response back to the request.

- Add constructor for viewproxy Server
- Add pass through functionality for GET requests
- Extract result into new file
