### PR TITLE
Add support for HMAC request verification

### DIFF
--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -16,7 +16,7 @@ func TestFetchReturnsMultipleResults(t *testing.T) {
 	server := startServer()
 
 	urls := []string{"http://localhost:9990?fragment=header", "http://localhost:9990?fragment=footer"}
-	results, err := Fetch(context.TODO(), urls, http.Header{}, defaultTimeout)
+	results, err := Fetch(context.TODO(), urls, http.Header{}, defaultTimeout, "")
 
 	assert.Nil(t, err)
 
@@ -42,7 +42,7 @@ func TestFetchForwardsHeaders(t *testing.T) {
 	}
 
 	urls := []string{"http://localhost:9990?fragment=echo_headers"}
-	results, err := Fetch(context.TODO(), urls, headers, defaultTimeout)
+	results, err := Fetch(context.TODO(), urls, headers, defaultTimeout, "")
 
 	assert.Nil(t, err)
 
@@ -55,7 +55,7 @@ func TestFetch404ReturnsError(t *testing.T) {
 	server := startServer()
 
 	urls := []string{"http://localhost:9990/wowomg"}
-	results, err := Fetch(context.TODO(), urls, http.Header{}, defaultTimeout)
+	results, err := Fetch(context.TODO(), urls, http.Header{}, defaultTimeout, "")
 
 	assert.ErrorIs(t, err, NotFoundErr)
 	assert.EqualError(t, err, "URL http://localhost:9990/wowomg: Not found")
@@ -70,7 +70,7 @@ func TestFetch500ReturnsError(t *testing.T) {
 
 	urls := []string{"http://localhost:9990/?fragment=oops", "http://localhost:9990?fragment=slow"}
 	ctx := context.Background()
-	results, err := Fetch(ctx, urls, http.Header{}, defaultTimeout)
+	results, err := Fetch(ctx, urls, http.Header{}, defaultTimeout, "")
 
 	duration := time.Since(start)
 
@@ -87,7 +87,7 @@ func TestFetchTimeout(t *testing.T) {
 	start := time.Now()
 
 	urls := []string{"http://localhost:9990?fragment=slow"}
-	_, err := Fetch(context.Background(), urls, http.Header{}, time.Duration(100)*time.Millisecond)
+	_, err := Fetch(context.Background(), urls, http.Header{}, time.Duration(100)*time.Millisecond, "")
 	duration := time.Since(start)
 
 	assert.EqualError(t, err, "context deadline exceeded")

--- a/server.go
+++ b/server.go
@@ -22,6 +22,14 @@ type Server struct {
 	DefaultPageTitle string
 	ignoreHeaders    []string
 	PassThrough      bool
+	// Sets the secret used to generate an HMAC that can be used by the target
+	// server to validate that a request came from viewproxy.
+	//
+	// When set, two headers are sent to the target URL for fragment and layout
+	// requests. The `X-Authorization-Timestamp` header, which is a timestamp
+	// generated at the start of the request, and `X-Authorization`, which is a
+	// hex encoded HMAC of "urlWithQueryParams,timestamp`.
+	HmacSecret string
 }
 
 var setMember struct{}
@@ -102,6 +110,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			route.fragmentsWithParameters(parameters),
 			multiplexer.HeadersFromRequest(r),
 			s.ProxyTimeout,
+			s.HmacSecret,
 		)
 
 		if err != nil {

--- a/server.go
+++ b/server.go
@@ -28,7 +28,7 @@ type Server struct {
 	// When set, two headers are sent to the target URL for fragment and layout
 	// requests. The `X-Authorization-Timestamp` header, which is a timestamp
 	// generated at the start of the request, and `X-Authorization`, which is a
-	// hex encoded HMAC of "urlWithQueryParams,timestamp`.
+	// hex encoded HMAC of "urlPathWithQueryParams,timestamp`.
 	HmacSecret string
 }
 


### PR DESCRIPTION
This adds support for sending an `Authorization` header to the target
server when requesting page fragments. This should help prevent
unauthorized access of fragment/layout endpoints.

A timestamp is included as an `X-Authorization-Time` header which is
also part of the HMAC itself, allowing target servers to implement their
own expiration logic.
