### PR TITLE
Use logger interface instead of log.Logger struct

### DIFF
--- a/server.go
+++ b/server.go
@@ -12,12 +12,24 @@ import (
 	"github.com/blakewilliams/viewproxy/pkg/multiplexer"
 )
 
+type logger interface {
+	Fatal(v ...interface{})
+	Fatalf(format string, v ...interface{})
+	Fatalln(v ...interface{})
+	Panic(v ...interface{})
+	Panicf(format string, v ...interface{})
+	Panicln(v ...interface{})
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
+}
+
 type Server struct {
 	Port             int
 	ProxyTimeout     time.Duration
 	routes           []Route
 	target           string
-	Logger           *log.Logger
+	Logger           logger
 	httpServer       *http.Server
 	DefaultPageTitle string
 	ignoreHeaders    []string


### PR DESCRIPTION
This copies the standard libraries logger interface so any logger that
complies with the interface can be plugged into viewproxy.
