### PR TITLE
Minor cleanup, add linters

### DIFF
--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -161,12 +161,12 @@ func FetchUrl(ctx context.Context, url string, headers http.Header) (*Result, er
 
 	// 404 is a failure, we should cancel the other requests
 	if result.StatusCode == 404 {
-		return nil, fmt.Errorf("URL %s: %w", url, NotFoundErr)
+		return nil, fmt.Errorf("URL %s: %w", url, ErrNotFound)
 	}
 
 	// Any non 2xx status code should be considered an error
 	if !(result.StatusCode >= 200 && result.StatusCode <= 299) {
-		return nil, fmt.Errorf("Status %d for URL %s: %w", result.StatusCode, url, Non2xxErr)
+		return nil, fmt.Errorf("status %d for URL %s: %w", result.StatusCode, url, ErrNon2xx)
 	}
 
 	return result, nil

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -38,7 +38,7 @@ func TestFetchReturnsMultipleResults(t *testing.T) {
 func TestFetchForwardsHeaders(t *testing.T) {
 	server := startServer()
 	headers := map[string][]string{
-		"X-Name": []string{"viewproxy"},
+		"X-Name": {"viewproxy"},
 	}
 
 	urls := []string{"http://localhost:9990?fragment=echo_headers"}
@@ -57,8 +57,8 @@ func TestFetch404ReturnsError(t *testing.T) {
 	urls := []string{"http://localhost:9990/wowomg"}
 	results, err := Fetch(context.TODO(), urls, http.Header{}, defaultTimeout, "")
 
-	assert.ErrorIs(t, err, NotFoundErr)
-	assert.EqualError(t, err, "URL http://localhost:9990/wowomg: Not found")
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.EqualError(t, err, "URL http://localhost:9990/wowomg: not found")
 	assert.Equal(t, 0, len(results), "Expected 0 results")
 
 	server.Close()
@@ -75,8 +75,8 @@ func TestFetch500ReturnsError(t *testing.T) {
 	duration := time.Since(start)
 
 	assert.Less(t, duration, time.Duration(3)*time.Second)
-	assert.ErrorIs(t, err, Non2xxErr)
-	assert.EqualError(t, err, "Status 500 for URL http://localhost:9990/?fragment=oops: Status code not in 2xx range")
+	assert.ErrorIs(t, err, ErrNon2xx)
+	assert.EqualError(t, err, "status 500 for URL http://localhost:9990/?fragment=oops: status code not in 2xx range")
 	assert.Equal(t, 0, len(results), "Expected 0 results")
 
 	server.Close()

--- a/pkg/multiplexer/result.go
+++ b/pkg/multiplexer/result.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-var NotFoundErr = errors.New("Not found")
-var Non2xxErr = errors.New("Status code not in 2xx range")
+var ErrNotFound = errors.New("not found")
+var ErrNon2xx = errors.New("status code not in 2xx range")
 
 type Result struct {
 	Url          string

--- a/server.go
+++ b/server.go
@@ -44,8 +44,6 @@ type Server struct {
 	HmacSecret string
 }
 
-var setMember struct{}
-
 func NewServer(target string) *Server {
 	return &Server{
 		DefaultPageTitle: "viewproxy",
@@ -185,7 +183,6 @@ func (s *Server) handleProxyError(err error, w http.ResponseWriter) {
 	s.Logger.Printf("Pass through error: %v", err)
 	w.WriteHeader(http.StatusInternalServerError)
 	w.Write([]byte("Internal Server Error"))
-	return
 }
 
 func (s *Server) ListenAndServe() error {

--- a/server_test.go
+++ b/server_test.go
@@ -43,6 +43,7 @@ func TestBasicServer(t *testing.T) {
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
 	expected := "<html><body>hello world</body></html>"
 
 	assert.Equal(t, expected, string(body))
@@ -87,6 +88,7 @@ func TestServerFromConfig(t *testing.T) {
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
 	expected := "<html><body>hello world</body></html>"
 
 	assert.Equal(t, expected, string(body))
@@ -115,6 +117,7 @@ func TestPassThroughEnabled(t *testing.T) {
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
 
 	assert.Equal(t, 500, resp.StatusCode)
 	assert.Equal(t, "Something went wrong", string(body))
@@ -143,6 +146,7 @@ func TestPassThroughDisabled(t *testing.T) {
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
 
 	assert.Equal(t, 404, resp.StatusCode)
 	assert.Equal(t, "404 not found", string(body))
@@ -174,10 +178,8 @@ func TestPassThroughSetsCorrectHeaders(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	select {
-	case <-done:
-		server.Close()
-	}
+	<-done
+	server.Close()
 }
 
 func TestPassThroughPostRequest(t *testing.T) {
@@ -208,10 +210,8 @@ func TestPassThroughPostRequest(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	select {
-	case <-done:
-		server.Close()
-	}
+	<-done
+	server.Close()
 }
 
 func TestFragmentSendsVerifiableHmacWhenSet(t *testing.T) {


### PR DESCRIPTION
* use `httptest.Server` in `server_test.go`
* Fix up some linter warnings