### PR TITLE
Add prerequest callback function to server

### DIFF
--- a/server.go
+++ b/server.go
@@ -44,8 +44,6 @@ type Server struct {
 	HmacSecret string
 }
 
-var setMember struct{}
-
 func NewServer(target string) *Server {
 	return &Server{
 		DefaultPageTitle: "viewproxy",
@@ -185,7 +183,6 @@ func (s *Server) handleProxyError(err error, w http.ResponseWriter) {
 	s.Logger.Printf("Pass through error: %v", err)
 	w.WriteHeader(http.StatusInternalServerError)
 	w.Write([]byte("Internal Server Error"))
-	return
 }
 
 func (s *Server) ListenAndServe() error {

--- a/server.go
+++ b/server.go
@@ -42,6 +42,8 @@ type Server struct {
 	// generated at the start of the request, and `X-Authorization`, which is a
 	// hex encoded HMAC of "urlPathWithQueryParams,timestamp`.
 	HmacSecret string
+	// A function that is called before the request is handled by viewproxy.
+	PreRequest func(w http.ResponseWriter, r *http.Request)
 }
 
 func NewServer(target string) *Server {
@@ -51,6 +53,7 @@ func NewServer(target string) *Server {
 		Port:             3005,
 		ProxyTimeout:     time.Duration(10) * time.Second,
 		PassThrough:      false,
+		PreRequest:       func(http.ResponseWriter, *http.Request) {},
 		target:           target,
 		ignoreHeaders:    make([]string, 0),
 		routes:           make([]Route, 0),
@@ -110,6 +113,7 @@ func (s *Server) matchingRoute(path string) (*Route, map[string]string) {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.PreRequest(w, r)
 	route, parameters := s.matchingRoute(r.URL.Path)
 
 	if route != nil {


### PR DESCRIPTION
This adds new field to the `Server` struct, `PreRequest`. This function
is called before the `http.Request` is handled by viewproxy.

This will be useful for logging information like the IP address of the
user requesting the page.