### PR TITLE
Add ability to load routes from pre-read JSON files

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,11 +25,13 @@ func readConfigFile(filePath string) ([]configRouteEntry, error) {
 		return nil, err
 	}
 
+	return loadJsonConfig(routesJson)
+}
+
+func loadJsonConfig(routesJson []byte) ([]configRouteEntry, error) {
 	var routeEntries []configRouteEntry
 
-	err = json.Unmarshal(routesJson, &routeEntries)
-
-	if err != nil {
+	if err := json.Unmarshal(routesJson, &routeEntries); err != nil {
 		return nil, err
 	}
 

--- a/server.go
+++ b/server.go
@@ -76,7 +76,7 @@ func (s *Server) IgnoreHeader(name string) {
 	s.ignoreHeaders = append(s.ignoreHeaders, name)
 }
 
-func (s *Server) LoadRouteConfig(filePath string) error {
+func (s *Server) LoadRoutesFromFile(filePath string) error {
 	routeEntries, err := readConfigFile(filePath)
 	if err != nil {
 		return err

--- a/server.go
+++ b/server.go
@@ -82,6 +82,19 @@ func (s *Server) LoadRouteConfig(filePath string) error {
 		return err
 	}
 
+	return s.loadRoutes(routeEntries)
+}
+
+func (s *Server) LoadRoutesFromJSON(routesJson string) error {
+	routeEntries, err := loadJsonConfig([]byte(routesJson))
+	if err != nil {
+		return err
+	}
+
+	return s.loadRoutes(routeEntries)
+}
+
+func (s *Server) loadRoutes(routeEntries []configRouteEntry) error {
 	for _, routeEntry := range routeEntries {
 		s.Logger.Printf("Defining %s, with layout %s, for fragments %v\n", routeEntry.Url, routeEntry.LayoutFragmentUrl, routeEntry.FragmentUrls)
 		s.Get(routeEntry.Url, routeEntry.LayoutFragmentUrl, routeEntry.FragmentUrls)

--- a/server_test.go
+++ b/server_test.go
@@ -74,7 +74,7 @@ func TestServerFromConfig(t *testing.T) {
 	viewProxyServer.Port = 9998
 	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
 
-	viewProxyServer.LoadRouteConfig(file.Name())
+	viewProxyServer.LoadRoutesFromFile(file.Name())
 	go func() {
 		if err := viewProxyServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			panic(err)


### PR DESCRIPTION
This adds the ability to load routes from `[]byte` which is useful when using `//go:embed`