### PR TITLE
Set tracing attributes for each fragment metadata key/value

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ server.PassThrough = true
 // This will make a layout request and 3 fragment requests, one for the header, hello, and footer.
 
 // GET http://localhost:3000/_view_fragments/layouts/my_layout?name=world
-server.Get("/hello/:name", "my_layout", []string{
-	"header", // GET http://localhost:3000/_view_fragments/header?name=world
-	"hello",  // GET http://localhost:3000/_view_fragments/hello?name=world
-	"footer", // GET http://localhost:3000/_view_fragments/footer?name=world
+layout := viewproxy.NewFragment("my_layout")
+server.Get("/hello/:name", layout, []*viewproxy.Fragment{
+	viewproxy.NewFragment("header"), // GET http://localhost:3000/_view_fragments/header?name=world
+	viewproxy.NewFragment("hello"),  // GET http://localhost:3000/_view_fragments/hello?name=world
+	viewproxy.NewFragment("footer"), // GET http://localhost:3000/_view_fragments/footer?name=world
 })
 
 server.ListenAndServe()
@@ -55,6 +56,17 @@ viewProxyServer.ConfigureTracing(
 	"my-viewproxy-service", // service name
 	false, // insecure mode?
 }
+```
+
+### Tracing attributes via fragment metadata
+
+Each fragment can be configured with a static map of key/values, which will be set as tracing attributes when each fragment is fetched.
+
+```go
+layout := viewproxy.NewFragment("my_layout")
+server.Get("/hello/:name", layout, []*viewproxy.Fragment{
+	viewproxy.NewFragmentWithMetadata("header", map[string]string{"page": "homepage"}), // spans will have a "page" attribute with value "homepage"
+})
 ```
 
 ## Philosophy

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -20,10 +20,11 @@ func main() {
 	server.IgnoreHeader("etag")
 	server.PassThrough = true
 
-	server.Get("/hello/:name", "my_layout", []string{
-		"header",
-		"hello",
-		"footer",
+	layout := viewproxy.NewFragment("my_layout")
+	server.Get("/hello/:name", layout, []*viewproxy.Fragment{
+		viewproxy.NewFragmentWithMetadata("header", map[string]string{"title": "Hello"}),
+		viewproxy.NewFragment("hello"),
+		viewproxy.NewFragment("footer"),
 	})
 
 	server.ListenAndServe()

--- a/config.go
+++ b/config.go
@@ -7,9 +7,9 @@ import (
 )
 
 type configRouteEntry struct {
-	Url               string   `json:"url"`
-	LayoutFragmentUrl string   `json:"layout"`
-	FragmentUrls      []string `json:"fragments"`
+	Url       string      `json:"url"`
+	Layout    *Fragment   `json:"layout"`
+	Fragments []*Fragment `json:"fragments"`
 }
 
 func readConfigFile(filePath string) ([]configRouteEntry, error) {

--- a/fragment.go
+++ b/fragment.go
@@ -40,7 +40,6 @@ func (f *Fragment) PreloadUrl(target string) {
 	)
 
 	if err != nil {
-		//TODO: that's not true anymore :)
 		// It should be okay to panic here, since this should only be called at boot time
 		panic(err)
 	}

--- a/fragment.go
+++ b/fragment.go
@@ -1,0 +1,49 @@
+package viewproxy
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type Fragment struct {
+	Path     string `json:"path"`
+	Url      string
+	Metadata map[string]string `json:"metadata"`
+}
+
+func NewFragment(path string) *Fragment {
+	return &Fragment{
+		Path:     path,
+		Metadata: make(map[string]string),
+	}
+}
+
+func NewFragmentWithMetadata(path string, metadata map[string]string) *Fragment {
+	return &Fragment{
+		Path:     path,
+		Metadata: metadata,
+	}
+}
+
+func (f *Fragment) UrlWithParams(parameters url.Values) string {
+	// This is already parsed before constructing the url in server.go, so we ignore errors
+	targetUrl, _ := url.Parse(f.Url)
+	targetUrl.RawQuery = parameters.Encode()
+
+	return targetUrl.String()
+}
+
+func (f *Fragment) PreloadUrl(target string) {
+	targetUrl, err := url.Parse(
+		fmt.Sprintf("%s/%s", strings.TrimRight(target, "/"), strings.TrimLeft(f.Path, "/")),
+	)
+
+	if err != nil {
+		//TODO: that's not true anymore :)
+		// It should be okay to panic here, since this should only be called at boot time
+		panic(err)
+	}
+
+	f.Url = targetUrl.String()
+}

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -17,8 +17,8 @@ func TestRequestDoReturnsMultipleResponsesInOrder(t *testing.T) {
 	urls := []string{"http://localhost:9990?fragment=header", "http://localhost:9990?fragment=footer"}
 
 	r := NewRequest()
-	r.WithFragment(urls[0])
-	r.WithFragment(urls[1])
+	r.WithFragment(urls[0], make(map[string]string))
+	r.WithFragment(urls[1], make(map[string]string))
 	r.Timeout = defaultTimeout
 	results, err := r.Do(context.TODO())
 
@@ -47,7 +47,7 @@ func TestRequestDoForwardsHeaders(t *testing.T) {
 	fakeHTTPRequest := &http.Request{Header: headers}
 
 	r := NewRequest()
-	r.WithFragment("http://localhost:9990?fragment=echo_headers")
+	r.WithFragment("http://localhost:9990?fragment=echo_headers", make(map[string]string))
 	r.WithHeadersFromRequest(fakeHTTPRequest)
 	r.Timeout = defaultTimeout
 	results, err := r.Do(context.TODO())
@@ -63,7 +63,7 @@ func TestFetch404ReturnsError(t *testing.T) {
 	server := startServer()
 
 	r := NewRequest()
-	r.WithFragment("http://localhost:9990/wowomg")
+	r.WithFragment("http://localhost:9990/wowomg", make(map[string]string))
 	r.Timeout = defaultTimeout
 	results, err := r.Do(context.TODO())
 
@@ -80,8 +80,8 @@ func TestFetch500ReturnsError(t *testing.T) {
 
 	urls := []string{"http://localhost:9990/?fragment=oops", "http://localhost:9990?fragment=slow"}
 	r := NewRequest()
-	r.WithFragment(urls[0])
-	r.WithFragment(urls[1])
+	r.WithFragment(urls[0], make(map[string]string))
+	r.WithFragment(urls[1], make(map[string]string))
 	results, err := r.Do(context.TODO())
 
 	duration := time.Since(start)
@@ -99,7 +99,7 @@ func TestFetchTimeout(t *testing.T) {
 	start := time.Now()
 
 	r := NewRequest()
-	r.WithFragment("http://localhost:9990?fragment=slow")
+	r.WithFragment("http://localhost:9990?fragment=slow", make(map[string]string))
 	r.Timeout = time.Duration(100) * time.Millisecond
 	_, err := r.Do(context.Background())
 	duration := time.Since(start)
@@ -115,7 +115,7 @@ func TestCanIgnoreNon2xxErrors(t *testing.T) {
 
 	ctx := context.Background()
 	r := NewRequest()
-	r.WithFragment("http://localhost:9990?fragment=slow")
+	r.WithFragment("http://localhost:9990?fragment=slow", make(map[string]string))
 	r.Timeout = time.Duration(100) * time.Millisecond
 	r.Non2xxErrors = false
 	_, err := r.Do(context.Background())

--- a/route.go
+++ b/route.go
@@ -1,17 +1,16 @@
 package viewproxy
 
 import (
-	"net/url"
 	"strings"
 )
 
 type Route struct {
 	Parts     []string
-	Layout    string
-	fragments []string
+	Layout    *Fragment
+	fragments []*Fragment
 }
 
-func newRoute(path string, layout string, fragments []string) *Route {
+func newRoute(path string, layout *Fragment, fragments []*Fragment) *Route {
 	return &Route{
 		Parts:     strings.Split(path, "/"),
 		Layout:    layout,
@@ -46,26 +45,12 @@ func (r *Route) parametersFor(pathParts []string) map[string]string {
 	return parameters
 }
 
-func (r *Route) fragmentsWithParameters(parameters map[string]string) []string {
-	query := url.Values{}
-	for name, value := range parameters {
-		query.Add(name, value)
-	}
-
-	urls := make([]string, len(r.fragments)+1)
-	urls[0] = fragmentToUrl(r.Layout, query)
+func (r *Route) FragmentsToRequest() []*Fragment {
+	fragments := make([]*Fragment, len(r.fragments)+1)
+	fragments[0] = r.Layout
 
 	for i, fragment := range r.fragments {
-		urls[i+1] = fragmentToUrl(fragment, query)
+		fragments[i+1] = fragment
 	}
-
-	return urls
-}
-
-func fragmentToUrl(fragment string, parameters url.Values) string {
-	// This is already parsed before constructing the url in server.go, so we ignore errors
-	targetUrl, _ := url.Parse(fragment)
-	targetUrl.RawQuery = parameters.Encode()
-
-	return targetUrl.String()
+	return fragments
 }

--- a/route_test.go
+++ b/route_test.go
@@ -24,7 +24,7 @@ func TestRouteMatch(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			route := newRoute(test.routePath, "", make([]string, 0))
+			route := newRoute(test.routePath, NewFragment(""), []*Fragment{})
 			providedUrlParts := strings.Split(test.providedUrl, "/")
 			got := route.matchParts(providedUrlParts)
 
@@ -47,7 +47,7 @@ func TestRouteParameters(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			route := newRoute(test.routePath, "", make([]string, 0))
+			route := newRoute(test.routePath, NewFragment(""), []*Fragment{})
 			providedUrlParts := strings.Split(test.providedUrl, "/")
 			got := route.parametersFor(providedUrlParts)
 
@@ -59,7 +59,11 @@ func TestRouteParameters(t *testing.T) {
 }
 
 func TestLayout(t *testing.T) {
-	route := newRoute("/", "my_layout", make([]string, 0))
+	route := newRoute("/", NewFragment("my_layout"), []*Fragment{})
 
-	assert.Equal(t, route.Layout, "my_layout")
+	assert.Equal(t, *route.Layout, Fragment{
+		Path:     "my_layout",
+		Url:      "",
+		Metadata: map[string]string{},
+	})
 }


### PR DESCRIPTION
This allows each fragment to be configured with a static map of
key/values, which will be set as tracing attributes when each fragment
is fetched.

See README for updated usage