### PR TITLE
Add ability to handle errors

### DIFF
--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -167,16 +167,13 @@ func (r *Request) fetchUrl(ctx context.Context, method string, url string, heade
 
 	duration := time.Since(start)
 
-	if r.Non2xxErrors {
-		// 404 is a failure, we should cancel the other requests
-		if resp.StatusCode == 404 {
-			return nil, fmt.Errorf("URL %s: %w", url, NotFoundErr)
+	if r.Non2xxErrors && (resp.StatusCode < 200 || resp.StatusCode > 299) {
+		err := &ResultError{
+			StatusCode: resp.StatusCode,
+			Url:        url,
 		}
 
-		// Any non 2xx status code should be considered an error
-		if !(resp.StatusCode >= 200 && resp.StatusCode <= 299) {
-			return nil, fmt.Errorf("Status %d for URL %s: %w", resp.StatusCode, url, Non2xxErr)
-		}
+		return nil, err
 	}
 
 	var responseBody []byte

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -69,8 +69,8 @@ func TestFetch404ReturnsError(t *testing.T) {
 
 	var resultErr *ResultError
 	assert.ErrorAs(t, err, &resultErr)
-	assert.Equal(t, 404, resultErr.StatusCode)
-	assert.Equal(t, "http://localhost:9990/wowomg", resultErr.Url)
+	assert.Equal(t, 404, resultErr.Result.StatusCode)
+	assert.Equal(t, "http://localhost:9990/wowomg", resultErr.Result.Url)
 	assert.Equal(t, 0, len(results), "Expected 0 results")
 
 	server.Close()
@@ -91,8 +91,8 @@ func TestFetch500ReturnsError(t *testing.T) {
 	assert.Less(t, duration, time.Duration(3)*time.Second)
 	var resultErr *ResultError
 	assert.ErrorAs(t, err, &resultErr)
-	assert.Equal(t, 500, resultErr.StatusCode)
-	assert.Equal(t, "http://localhost:9990/?fragment=oops", resultErr.Url)
+	assert.Equal(t, 500, resultErr.Result.StatusCode)
+	assert.Equal(t, "http://localhost:9990/?fragment=oops", resultErr.Result.Url)
 	assert.Equal(t, 0, len(results), "Expected 0 results")
 
 	server.Close()

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -67,8 +67,10 @@ func TestFetch404ReturnsError(t *testing.T) {
 	r.Timeout = defaultTimeout
 	results, err := r.Do(context.TODO())
 
-	assert.ErrorIs(t, err, NotFoundErr)
-	assert.EqualError(t, err, "URL http://localhost:9990/wowomg: Not found")
+	var resultErr *ResultError
+	assert.ErrorAs(t, err, &resultErr)
+	assert.Equal(t, 404, resultErr.StatusCode)
+	assert.Equal(t, "http://localhost:9990/wowomg", resultErr.Url)
 	assert.Equal(t, 0, len(results), "Expected 0 results")
 
 	server.Close()
@@ -87,8 +89,10 @@ func TestFetch500ReturnsError(t *testing.T) {
 	duration := time.Since(start)
 
 	assert.Less(t, duration, time.Duration(3)*time.Second)
-	assert.ErrorIs(t, err, Non2xxErr)
-	assert.EqualError(t, err, "Status 500 for URL http://localhost:9990/?fragment=oops: Status code not in 2xx range")
+	var resultErr *ResultError
+	assert.ErrorAs(t, err, &resultErr)
+	assert.Equal(t, 500, resultErr.StatusCode)
+	assert.Equal(t, "http://localhost:9990/?fragment=oops", resultErr.Url)
 	assert.Equal(t, 0, len(results), "Expected 0 results")
 
 	server.Close()

--- a/pkg/multiplexer/result.go
+++ b/pkg/multiplexer/result.go
@@ -1,13 +1,23 @@
 package multiplexer
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 	"time"
 )
 
-var NotFoundErr = errors.New("Not found")
-var Non2xxErr = errors.New("Status code not in 2xx range")
+type ResultError struct {
+	StatusCode int
+	Url        string
+}
+
+func (re *ResultError) Error() string {
+	return fmt.Sprintf(
+		"status: %d url: %s",
+		re.StatusCode,
+		re.Url,
+	)
+}
 
 type Result struct {
 	Url          string

--- a/pkg/multiplexer/result.go
+++ b/pkg/multiplexer/result.go
@@ -7,15 +7,14 @@ import (
 )
 
 type ResultError struct {
-	StatusCode int
-	Url        string
+	Result *Result
 }
 
 func (re *ResultError) Error() string {
 	return fmt.Sprintf(
 		"status: %d url: %s",
-		re.StatusCode,
-		re.Url,
+		re.Result.StatusCode,
+		re.Result.Url,
 	)
 }
 

--- a/server.go
+++ b/server.go
@@ -15,6 +15,9 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// Re-export ResultError for convenience
+type ResultError = multiplexer.ResultError
+
 type logger interface {
 	Fatal(v ...interface{})
 	Fatalf(format string, v ...interface{})

--- a/server_test.go
+++ b/server_test.go
@@ -409,8 +409,8 @@ func TestOnErrorHandler(t *testing.T) {
 		var resultErr *ResultError
 
 		assert.ErrorAs(t, e, &resultErr)
-		assert.Equal(t, "http://localhost:9994/oops?name=world", resultErr.Url)
-		assert.Equal(t, 500, resultErr.StatusCode)
+		assert.Equal(t, "http://localhost:9994/oops?name=world", resultErr.Result.Url)
+		assert.Equal(t, 500, resultErr.Result.StatusCode)
 	}
 
 	fakeWriter := httptest.NewRecorder()
@@ -447,8 +447,8 @@ func TestOnError404Handler(t *testing.T) {
 		var resultErr *ResultError
 
 		assert.ErrorAs(t, e, &resultErr)
-		assert.Equal(t, "http://localhost:9994/definitely_missing_and_not_defined?name=world", resultErr.Url)
-		assert.Equal(t, 404, resultErr.StatusCode)
+		assert.Equal(t, "http://localhost:9994/definitely_missing_and_not_defined?name=world", resultErr.Result.Url)
+		assert.Equal(t, 404, resultErr.Result.StatusCode)
 	}
 
 	fakeWriter := httptest.NewRecorder()

--- a/server_test.go
+++ b/server_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -386,6 +387,83 @@ func TestPrerequestCallback(t *testing.T) {
 	assert.Equal(t, "true", fakeWriter.Header().Get("x-viewproxy"))
 
 	<-done
+}
+
+func TestOnErrorHandler(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+
+	targetServer := startTargetServer()
+	defer targetServer.Shutdown(context.TODO())
+
+	server := NewServer("http://localhost:9994")
+	server.Get("/hello/:name", NewFragment("/oops"), []*Fragment{})
+
+	server.PreRequest = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-viewproxy", "true")
+		assert.Equal(t, "192.168.1.1", r.RemoteAddr)
+	}
+	server.OnError = func(w http.ResponseWriter, r *http.Request, e error) {
+		defer close(done)
+		var resultErr *ResultError
+
+		assert.ErrorAs(t, e, &resultErr)
+		assert.Equal(t, "http://localhost:9994/oops?name=world", resultErr.Url)
+		assert.Equal(t, 500, resultErr.StatusCode)
+	}
+
+	fakeWriter := httptest.NewRecorder()
+	fakeRequest := httptest.NewRequest("GET", "/hello/world", nil)
+	fakeRequest.RemoteAddr = "192.168.1.1"
+
+	server.ServeHTTP(fakeWriter, fakeRequest)
+
+	assert.Equal(t, "true", fakeWriter.Header().Get("x-viewproxy"))
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		assert.Fail(t, ctx.Err().Error())
+	}
+}
+
+func TestOnError404Handler(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+
+	targetServer := startTargetServer()
+	defer targetServer.Shutdown(context.TODO())
+
+	server := NewServer("http://localhost:9994")
+	server.Get("/hello/:name", NewFragment("/definitely_missing_and_not_defined"), []*Fragment{})
+	server.PreRequest = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-viewproxy", "true")
+		assert.Equal(t, "192.168.1.1", r.RemoteAddr)
+	}
+	server.OnError = func(w http.ResponseWriter, r *http.Request, e error) {
+		defer close(done)
+		var resultErr *ResultError
+
+		assert.ErrorAs(t, e, &resultErr)
+		assert.Equal(t, "http://localhost:9994/definitely_missing_and_not_defined?name=world", resultErr.Url)
+		assert.Equal(t, 404, resultErr.StatusCode)
+	}
+
+	fakeWriter := httptest.NewRecorder()
+	fakeRequest := httptest.NewRequest("GET", "/hello/world", nil)
+	fakeRequest.RemoteAddr = "192.168.1.1"
+
+	server.ServeHTTP(fakeWriter, fakeRequest)
+
+	assert.Equal(t, "true", fakeWriter.Header().Get("x-viewproxy"))
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		assert.Fail(t, ctx.Err().Error())
+	}
 }
 
 func startTargetServer() *http.Server {


### PR DESCRIPTION
Extract custom error type for result errors

Currently there are two error types that can come from a multiplexer
request, `Non2xxErr` and `NotFoundErr`. These are both simple error
types implemented via strings. This makes it difficult to extra any
extra information from the errors.

To enable us to expose more data via errors, this introduces a new error
struct, `ResultError`, which embeds the `Result` that caused the Error.
