### PR TITLE
Add query param forwarding to fragment requests

### DIFF
--- a/server.go
+++ b/server.go
@@ -168,6 +168,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			for name, value := range parameters {
 				query.Add(name, value)
 			}
+			for name, values := range r.URL.Query() {
+				if query.Get(name) == "" {
+					for _, value := range values {
+						query.Add(name, value)
+					}
+				}
+			}
+
 			req.WithFragment(f.UrlWithParams(query), f.Metadata)
 		}
 


### PR DESCRIPTION
This adds query param forwarding to fragment requests instead of
silently dropping them.

This accounts for named parameters and does not allow a user passed
query parameter to override a route parameter.

closes https://github.com/BlakeWilliams/viewproxy/issues/8
