### PR TITLE
Remove URL attribute from traces

### DIFF
--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -84,10 +84,6 @@ func (r *Request) Do(ctx context.Context) ([]*Result, error) {
 			defer wg.Done()
 			var span trace.Span
 			ctx, span = tracer.Start(ctx, "fetch_url")
-			span.SetAttributes(attribute.KeyValue{
-				Key:   "url",
-				Value: attribute.StringValue(f.url),
-			})
 			for key, value := range f.metadata {
 				span.SetAttributes(attribute.KeyValue{
 					Key:   attribute.Key(key),


### PR DESCRIPTION
Sometimes URL's can contain secrets that shouldn't be sent to third
parties.

This removes the URL and relies on the new metadata attributes to
identify traces.
