### PR TITLE
Add support for aggregating Server-Timing headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ server.Get("/hello/:name", layout, []*viewproxy.Fragment{
 
 Run the tests:
 
-```
+```sh
 go test ./...
+```
+
+## Server-Timing header aggregation
+
+The [`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing)
+header from all responses can be aggregated by using the `TimingLabel` setting
+on each fragments.
+
+For example if your server emits database timing metrics in the form of
+`db;dur=<duration>`, then the following example would generate a combined
+header of:
+
+```
+layout-db;desc="layout db";dur=<duration>,body-db;desc="body db";dur=<duration>
+```
+
+
+```go
+layout := viewproxy.NewFragment("my_layout")
+layout.TimingLabel = "layout"
+body := viewproxy.NewFragment("my_body")
+body.TimingLabel = "body"
+server.Get("/hello/:name", layout, []*viewproxy.Fragment{body})
 ```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ go test ./...
 
 The [`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing)
 header from all responses can be aggregated by using the `TimingLabel` setting
-on each fragments.
+on each fragment.
 
 For example if your server emits database timing metrics in the form of
 `db;dur=<duration>`, then the following example would generate a combined

--- a/fragment.go
+++ b/fragment.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Fragment struct {
-	Path     string `json:"path"`
-	Url      string
-	Metadata map[string]string `json:"metadata"`
+	Path        string `json:"path"`
+	Url         string
+	Metadata    map[string]string `json:"metadata"`
+	TimingLabel string
 }
 
 func NewFragment(path string) *Fragment {

--- a/fragment.go
+++ b/fragment.go
@@ -10,7 +10,7 @@ type Fragment struct {
 	Path        string `json:"path"`
 	Url         string
 	Metadata    map[string]string `json:"metadata"`
-	TimingLabel string
+	TimingLabel string            `json:"timingLabel"`
 }
 
 func NewFragment(path string) *Fragment {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/mitchellh/go-server-timing v1.0.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/contrib/propagators v0.20.0 // indirect
 	go.opentelemetry.io/otel v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,12 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/felixge/httpsnoop v1.0.0 h1:gh8fMGz0rlOv/1WmRZm7OgncIOTsAj21iNJot48omJQ=
+github.com/felixge/httpsnoop v1.0.0/go.mod h1:3+D9sFq0ahK/JeJPhCBUV1xlf4/eIYrUQaxulT0VzX8=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang/gddo v0.0.0-20180823221919-9d8ff1c67be5 h1:yrv1uUvgXH/tEat+wdvJMRJ4g51GlIydtDpU9pFjaaI=
+github.com/golang/gddo v0.0.0-20180823221919-9d8ff1c67be5/go.mod h1:xEhNfoBDX1hzLm2Nf80qUvZ2sVwoMZ8d6IE2SrsQfh4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -36,6 +40,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -43,6 +48,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/mitchellh/go-server-timing v1.0.1 h1:f00/aIe8T3MrnLhQHu3tSWvnwc5GV/p5eutuu3hF/tE=
+github.com/mitchellh/go-server-timing v1.0.1/go.mod h1:Mo6GKi9FSLwWFAMn3bqVPWe20y5ri5QGQuO9D9MCOxk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -21,8 +21,9 @@ import (
 )
 
 type fragment struct {
-	url      string
-	metadata map[string]string
+	url         string
+	metadata    map[string]string
+	timingLabel string
 }
 
 type Request struct {
@@ -57,8 +58,8 @@ func (r *Request) WithHeadersFromRequest(req *http.Request) {
 	}
 }
 
-func (r *Request) WithFragment(fragmentURL string, metadata map[string]string) {
-	r.fragments = append(r.fragments, fragment{url: fragmentURL, metadata: metadata})
+func (r *Request) WithFragment(fragmentURL string, metadata map[string]string, timingLabel string) {
+	r.fragments = append(r.fragments, fragment{url: fragmentURL, metadata: metadata, timingLabel: timingLabel})
 }
 
 func (r *Request) DoSingle(ctx context.Context, method string, url string, body io.ReadCloser) (*Result, error) {
@@ -105,9 +106,9 @@ func (r *Request) Do(ctx context.Context) ([]*Result, error) {
 
 			if err != nil {
 				errCh <- err
+			} else {
+				result.TimingLabel = f.timingLabel
 			}
-
-			result.metadata = f.metadata
 
 			resultsCh <- result
 		}(ctx, f, resultsCh, &wg)

--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -107,6 +107,8 @@ func (r *Request) Do(ctx context.Context) ([]*Result, error) {
 				errCh <- err
 			}
 
+			result.metadata = f.metadata
+
 			resultsCh <- result
 		}(ctx, f, resultsCh, &wg)
 	}

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -17,8 +17,8 @@ func TestRequestDoReturnsMultipleResponsesInOrder(t *testing.T) {
 	urls := []string{"http://localhost:9990?fragment=header", "http://localhost:9990?fragment=footer"}
 
 	r := NewRequest()
-	r.WithFragment(urls[0], make(map[string]string))
-	r.WithFragment(urls[1], make(map[string]string))
+	r.WithFragment(urls[0], make(map[string]string), "")
+	r.WithFragment(urls[1], make(map[string]string), "")
 	r.Timeout = defaultTimeout
 	results, err := r.Do(context.TODO())
 
@@ -47,7 +47,7 @@ func TestRequestDoForwardsHeaders(t *testing.T) {
 	fakeHTTPRequest := &http.Request{Header: headers}
 
 	r := NewRequest()
-	r.WithFragment("http://localhost:9990?fragment=echo_headers", make(map[string]string))
+	r.WithFragment("http://localhost:9990?fragment=echo_headers", make(map[string]string), "")
 	r.WithHeadersFromRequest(fakeHTTPRequest)
 	r.Timeout = defaultTimeout
 	results, err := r.Do(context.TODO())
@@ -63,7 +63,7 @@ func TestFetch404ReturnsError(t *testing.T) {
 	server := startServer()
 
 	r := NewRequest()
-	r.WithFragment("http://localhost:9990/wowomg", make(map[string]string))
+	r.WithFragment("http://localhost:9990/wowomg", make(map[string]string), "")
 	r.Timeout = defaultTimeout
 	results, err := r.Do(context.TODO())
 
@@ -82,8 +82,8 @@ func TestFetch500ReturnsError(t *testing.T) {
 
 	urls := []string{"http://localhost:9990/?fragment=oops", "http://localhost:9990?fragment=slow"}
 	r := NewRequest()
-	r.WithFragment(urls[0], make(map[string]string))
-	r.WithFragment(urls[1], make(map[string]string))
+	r.WithFragment(urls[0], make(map[string]string), "")
+	r.WithFragment(urls[1], make(map[string]string), "")
 	results, err := r.Do(context.TODO())
 
 	duration := time.Since(start)
@@ -103,7 +103,7 @@ func TestFetchTimeout(t *testing.T) {
 	start := time.Now()
 
 	r := NewRequest()
-	r.WithFragment("http://localhost:9990?fragment=slow", make(map[string]string))
+	r.WithFragment("http://localhost:9990?fragment=slow", make(map[string]string), "")
 	r.Timeout = time.Duration(100) * time.Millisecond
 	_, err := r.Do(context.Background())
 	duration := time.Since(start)
@@ -119,7 +119,7 @@ func TestCanIgnoreNon2xxErrors(t *testing.T) {
 
 	ctx := context.Background()
 	r := NewRequest()
-	r.WithFragment("http://localhost:9990?fragment=slow", make(map[string]string))
+	r.WithFragment("http://localhost:9990?fragment=slow", make(map[string]string), "")
 	r.Timeout = time.Duration(100) * time.Millisecond
 	r.Non2xxErrors = false
 	_, err := r.Do(context.Background())

--- a/pkg/multiplexer/result.go
+++ b/pkg/multiplexer/result.go
@@ -24,6 +24,7 @@ type Result struct {
 	HttpResponse *http.Response
 	Body         []byte
 	StatusCode   int
+	metadata     map[string]string
 }
 
 func (r *Result) Header() http.Header {

--- a/pkg/multiplexer/result.go
+++ b/pkg/multiplexer/result.go
@@ -24,7 +24,7 @@ type Result struct {
 	HttpResponse *http.Response
 	Body         []byte
 	StatusCode   int
-	metadata     map[string]string
+	TimingLabel  string
 }
 
 func (r *Result) Header() http.Header {

--- a/pkg/multiplexer/server_timing.go
+++ b/pkg/multiplexer/server_timing.go
@@ -8,7 +8,6 @@ import (
 )
 
 func SetServerTimingHeader(results []*Result, writer http.ResponseWriter) {
-	// Forward header directly if only one result
 	if len(results) == 1 {
 		value := results[0].HttpResponse.Header.Get(servertiming.HeaderKey)
 		if len(value) > 0 {
@@ -20,7 +19,7 @@ func SetServerTimingHeader(results []*Result, writer http.ResponseWriter) {
 	metrics := []*servertiming.Metric{}
 
 	for _, result := range results {
-		fragment, ok := result.metadata["timing"]
+		fragment, ok := result.metadata["timingPrefix"]
 
 		// Skip results with no timing label
 		if !ok {
@@ -34,6 +33,7 @@ func SetServerTimingHeader(results []*Result, writer http.ResponseWriter) {
 		}
 
 		for _, metric := range timings.Metrics {
+			// Ignore zero duration timings to reduce UI noise
 			if metric.Duration == 0 {
 				continue
 			}

--- a/pkg/multiplexer/server_timing.go
+++ b/pkg/multiplexer/server_timing.go
@@ -1,0 +1,56 @@
+package multiplexer
+
+import (
+	"net/http"
+	"strings"
+
+	servertiming "github.com/mitchellh/go-server-timing"
+)
+
+func SetServerTimingHeader(results []*Result, writer http.ResponseWriter) {
+	// Forward header directly if only one result
+	if len(results) == 1 {
+		value := results[0].HttpResponse.Header.Get(servertiming.HeaderKey)
+		if len(value) > 0 {
+			writer.Header().Set(servertiming.HeaderKey, value)
+		}
+		return
+	}
+
+	metrics := []*servertiming.Metric{}
+
+	for _, result := range results {
+		fragment, ok := result.metadata["timing"]
+
+		// Skip results with no timing label
+		if !ok {
+			continue
+		}
+
+		resultTiming := result.HttpResponse.Header.Get(servertiming.HeaderKey)
+		timings, err := servertiming.ParseHeader(resultTiming)
+		if err != nil {
+			continue
+		}
+
+		for _, metric := range timings.Metrics {
+			if metric.Duration == 0 {
+				continue
+			}
+			metric.Desc = fragment + " " + metric.Name
+			metric.Name = fragment + "-" + metric.Name
+			metrics = append(metrics, metric)
+		}
+	}
+
+	if len(metrics) == 0 {
+		return
+	}
+
+	segments := make([]string, 0, len(metrics))
+	for _, metric := range metrics {
+		segments = append(segments, metric.String())
+	}
+
+	writer.Header().Set(servertiming.HeaderKey, strings.Join(segments, ","))
+}

--- a/pkg/multiplexer/server_timing.go
+++ b/pkg/multiplexer/server_timing.go
@@ -7,22 +7,12 @@ import (
 	servertiming "github.com/mitchellh/go-server-timing"
 )
 
-func SetServerTimingHeader(results []*Result, writer http.ResponseWriter) {
-	if len(results) == 1 {
-		value := results[0].HttpResponse.Header.Get(servertiming.HeaderKey)
-		if len(value) > 0 {
-			writer.Header().Set(servertiming.HeaderKey, value)
-		}
-		return
-	}
-
+func AggregateServerTimingHeaders(results []*Result, writer http.ResponseWriter) {
 	metrics := []*servertiming.Metric{}
 
 	for _, result := range results {
-		fragment, ok := result.metadata["timingPrefix"]
-
 		// Skip results with no timing label
-		if !ok {
+		if len(result.TimingLabel) == 0 {
 			continue
 		}
 
@@ -37,8 +27,8 @@ func SetServerTimingHeader(results []*Result, writer http.ResponseWriter) {
 			if metric.Duration == 0 {
 				continue
 			}
-			metric.Desc = fragment + " " + metric.Name
-			metric.Name = fragment + "-" + metric.Name
+			metric.Desc = result.TimingLabel + " " + metric.Name
+			metric.Name = result.TimingLabel + "-" + metric.Name
 			metrics = append(metrics, metric)
 		}
 	}

--- a/pkg/multiplexer/server_timing.go
+++ b/pkg/multiplexer/server_timing.go
@@ -7,7 +7,7 @@ import (
 	servertiming "github.com/mitchellh/go-server-timing"
 )
 
-func AggregateServerTimingHeaders(results []*Result, writer http.ResponseWriter) {
+func SetCombinedServerTimingHeader(results []*Result, writer http.ResponseWriter) {
 	metrics := []*servertiming.Metric{}
 
 	for _, result := range results {

--- a/response_builder.go
+++ b/response_builder.go
@@ -35,7 +35,7 @@ func (rb *responseBuilder) SetHeaders(headers http.Header, results []*multiplexe
 	}
 
 	if len(results) > 1 {
-		multiplexer.AggregateServerTimingHeaders(results, rb.writer)
+		multiplexer.SetCombinedServerTimingHeader(results, rb.writer)
 	}
 }
 

--- a/response_builder.go
+++ b/response_builder.go
@@ -23,7 +23,7 @@ func (rb *responseBuilder) SetLayout(result *multiplexer.Result) {
 	rb.body = result.Body
 }
 
-func (rb *responseBuilder) SetHeaders(headers http.Header) {
+func (rb *responseBuilder) SetHeaders(headers http.Header, results []*multiplexer.Result) {
 	for name, values := range headers {
 		for _, value := range values {
 			rb.writer.Header().Add(name, value)
@@ -33,6 +33,8 @@ func (rb *responseBuilder) SetHeaders(headers http.Header) {
 	for _, ignoredHeader := range rb.server.ignoreHeaders {
 		rb.writer.Header().Del(ignoredHeader)
 	}
+
+	multiplexer.SetServerTimingHeader(results, rb.writer)
 }
 
 func (rb *responseBuilder) SetFragments(results []*multiplexer.Result) {

--- a/response_builder.go
+++ b/response_builder.go
@@ -34,7 +34,9 @@ func (rb *responseBuilder) SetHeaders(headers http.Header, results []*multiplexe
 		rb.writer.Header().Del(ignoredHeader)
 	}
 
-	multiplexer.SetServerTimingHeader(results, rb.writer)
+	if len(results) > 1 {
+		multiplexer.AggregateServerTimingHeaders(results, rb.writer)
+	}
 }
 
 func (rb *responseBuilder) SetFragments(results []*multiplexer.Result) {

--- a/server.go
+++ b/server.go
@@ -201,7 +201,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		resBuilder := newResponseBuilder(*s, w)
 		resBuilder.SetLayout(results[0])
-		resBuilder.SetHeaders(results[0].HeadersWithoutProxyHeaders())
+		resBuilder.SetHeaders(results[0].HeadersWithoutProxyHeaders(), results)
 		resBuilder.SetFragments(results[1:])
 		resBuilder.Write()
 	} else if s.PassThrough {
@@ -237,8 +237,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		resBuilder := newResponseBuilder(*s, w)
 		resBuilder.StatusCode = result.StatusCode
-		resBuilder.SetHeaders(result.HeadersWithoutProxyHeaders())
-		resBuilder.SetFragments([]*multiplexer.Result{result})
+		results := []*multiplexer.Result{result}
+		resBuilder.SetHeaders(result.HeadersWithoutProxyHeaders(), results)
+		resBuilder.SetFragments(results)
 		resBuilder.Write()
 	} else {
 		s.Logger.Printf("Rendering 404 for %s\n", r.URL.Path)

--- a/server.go
+++ b/server.go
@@ -176,7 +176,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			req.WithFragment(f.UrlWithParams(query), f.Metadata)
+			req.WithFragment(f.UrlWithParams(query), f.Metadata, f.TimingLabel)
 		}
 
 		req.WithHeadersFromRequest(r)

--- a/server_test.go
+++ b/server_test.go
@@ -206,8 +206,6 @@ func TestPassThroughSetsCorrectHeaders(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, "db;dur=53", resp.Header.Get("Server-Timing"))
-
-	server.Close()
 }
 
 func TestPassThroughPostRequest(t *testing.T) {


### PR DESCRIPTION
This pull request adds support for building a combined [`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing) header that includes the timings from each of the fragments with a configured prefix.

Setting a `TimingLabel` string on a fragment will cause it to re-format the `Server-Timing` header in the response to have a new name/description for each value from the individual requests.

Generating something like the following for a page with 3 fragments:

<img width="1687" alt="Screen Shot 2021-06-30 at 6 49 42 AM" src="https://user-images.githubusercontent.com/671378/123980880-be7a8180-d976-11eb-8907-3f3a892a562d.png">

