### PR TITLE
Expose AroundRequest instead of PreRequest

### DIFF
--- a/route.go
+++ b/route.go
@@ -5,6 +5,7 @@ import (
 )
 
 type Route struct {
+	Path      string
 	Parts     []string
 	Layout    *Fragment
 	fragments []*Fragment
@@ -12,6 +13,7 @@ type Route struct {
 
 func newRoute(path string, layout *Fragment, fragments []*Fragment) *Route {
 	return &Route{
+		Path:      path,
 		Parts:     strings.Split(path, "/"),
 		Layout:    layout,
 		fragments: fragments,

--- a/server.go
+++ b/server.go
@@ -59,6 +59,8 @@ type Server struct {
 	OnError func(w http.ResponseWriter, r *http.Request, e error)
 }
 
+const RouteContextKey = "viewproxy-route"
+
 func NewServer(target string) *Server {
 	return &Server{
 		DefaultPageTitle: "viewproxy",
@@ -163,10 +165,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			callbackCalled = true
 		})
 	} else {
-		ctxWithPath := context.WithValue(ctx, "viewproxy-route-path", route.Path)
+		ctxWithPath := context.WithValue(ctx, RouteContextKey, route)
 		rWithPath := r.WithContext(ctxWithPath)
 		s.AroundRequest(w, rWithPath, func() {
-			s.handleRequest(w, r, route, parameters, ctx)
+			s.handleRequest(w, rWithPath, route, parameters, ctx)
 			callbackCalled = true
 		})
 	}

--- a/server.go
+++ b/server.go
@@ -221,7 +221,7 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request, route *Ro
 
 	resBuilder := newResponseBuilder(*s, w)
 	resBuilder.SetLayout(results[0])
-	resBuilder.SetHeaders(results[0].HeadersWithoutProxyHeaders())
+	resBuilder.SetHeaders(results[0].HeadersWithoutProxyHeaders(), results)
 	resBuilder.SetFragments(results[1:])
 	resBuilder.Write()
 }

--- a/server_test.go
+++ b/server_test.go
@@ -348,14 +348,15 @@ func TestSupportsGzip(t *testing.T) {
 	server.Close()
 }
 
-func TestPrerequestCallback(t *testing.T) {
+func TestAroundRequestCallback(t *testing.T) {
 	done := make(chan struct{})
 
 	server := NewServer("http://fake.net")
-	server.PreRequest = func(w http.ResponseWriter, r *http.Request) {
+	server.AroundRequest = func(w http.ResponseWriter, r *http.Request, callback func()) {
 		defer close(done)
 		w.Header().Set("x-viewproxy", "true")
 		assert.Equal(t, "192.168.1.1", r.RemoteAddr)
+		callback()
 	}
 
 	w := httptest.NewRecorder()
@@ -378,8 +379,9 @@ func TestOnErrorHandler(t *testing.T) {
 
 	server := NewServer(targetServer.URL)
 	server.Get("/hello/:name", NewFragment("/definitely_missing_and_not_defined"), []*Fragment{})
-	server.PreRequest = func(w http.ResponseWriter, r *http.Request) {
+	server.AroundRequest = func(w http.ResponseWriter, r *http.Request, callback func()) {
 		w.Header().Set("x-viewproxy", "true")
+		callback()
 		assert.Equal(t, "192.168.1.1", r.RemoteAddr)
 	}
 	server.OnError = func(w http.ResponseWriter, r *http.Request, e error) {

--- a/server_test.go
+++ b/server_test.go
@@ -373,7 +373,7 @@ func TestAroundRequestCallback(t *testing.T) {
 	server.AroundRequest = func(w http.ResponseWriter, r *http.Request, callback func()) {
 		defer close(done)
 		w.Header().Set("x-viewproxy", "true")
-		assert.Equal(t, "/hello/:name", r.Context().Value("viewproxy-route-path").(string))
+		assert.Equal(t, "/hello/:name", r.Context().Value("viewproxy-route").(*Route).Path)
 		assert.Equal(t, "192.168.1.1", r.RemoteAddr)
 		callback()
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -352,15 +352,17 @@ func TestAroundRequestCallback(t *testing.T) {
 	done := make(chan struct{})
 
 	server := NewServer("http://fake.net")
+	server.Get("/hello/:name", NewFragment("/layout"), []*Fragment{NewFragment("/fragment")})
 	server.AroundRequest = func(w http.ResponseWriter, r *http.Request, callback func()) {
 		defer close(done)
 		w.Header().Set("x-viewproxy", "true")
+		assert.Equal(t, "/hello/:name", r.Context().Value("viewproxy-route-path").(string))
 		assert.Equal(t, "192.168.1.1", r.RemoteAddr)
 		callback()
 	}
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/", nil)
+	r := httptest.NewRequest("GET", "/hello/world", nil)
 	r.RemoteAddr = "192.168.1.1"
 
 	server.ServeHTTP(w, r)


### PR DESCRIPTION
This is more flexible, allowing users of viewproxy to log and measure the time spent in each request handled by viewproxy

Closes https://github.com/BlakeWilliams/viewproxy/issues/29

TODO:
- [x] How can we send an argument to AroundRequest that reveals the path pattern for this request? e.g. `path: "/:user/foo/:bar" so metrics/logs can be tagged accordingly?