### PR TITLE
Add fragment result duration to server timing header

### DIFF
--- a/pkg/multiplexer/server_timing.go
+++ b/pkg/multiplexer/server_timing.go
@@ -7,6 +7,8 @@ import (
 	servertiming "github.com/mitchellh/go-server-timing"
 )
 
+const resultTimingLabel = "fragment"
+
 func SetCombinedServerTimingHeader(results []*Result, writer http.ResponseWriter) {
 	metrics := []*servertiming.Metric{}
 
@@ -15,6 +17,12 @@ func SetCombinedServerTimingHeader(results []*Result, writer http.ResponseWriter
 		if len(result.TimingLabel) == 0 {
 			continue
 		}
+
+		metrics = append(metrics, &servertiming.Metric{
+			Desc:     result.TimingLabel + " " + resultTimingLabel,
+			Name:     result.TimingLabel + "-" + resultTimingLabel,
+			Duration: result.Duration,
+		})
 
 		resultTiming := result.HttpResponse.Header.Get(servertiming.HeaderKey)
 		timings, err := servertiming.ParseHeader(resultTiming)

--- a/server_test.go
+++ b/server_test.go
@@ -335,7 +335,10 @@ func TestFragmentSetsCorrectHeaders(t *testing.T) {
 
 	resp := w.Result()
 
-	assert.Equal(t, "foo-db;desc=\"foo db\";dur=12,bar-db;desc=\"bar db\";dur=34", resp.Header.Get("Server-Timing"))
+	assert.Contains(t, resp.Header.Get("Server-Timing"), "foo-db;desc=\"foo db\";dur=12")
+	assert.Contains(t, resp.Header.Get("Server-Timing"), "bar-db;desc=\"bar db\";dur=34")
+	assert.Contains(t, resp.Header.Get("Server-Timing"), "foo-fragment;desc=\"foo fragment\";dur=")
+	assert.Contains(t, resp.Header.Get("Server-Timing"), "bar-fragment;desc=\"bar fragment\";dur=")
 
 	server.Close()
 }


### PR DESCRIPTION
This pull request is a follow on to #34, it adds a `Server-Timing` of the duration of each fragment result that has a `timingLabel` configured.

This timing will give the total request timing for fragment as experienced by viewproxy.