### PR TITLE
Panic when an error occurs

### DIFF
--- a/server.go
+++ b/server.go
@@ -55,8 +55,6 @@ type Server struct {
 	// A function to wrap request handling with other middleware
 	AroundRequest func(http.Handler) http.Handler
 	tracingConfig tracing.TracingConfig
-	// A function that is called when an error occurs in the viewproxy handler
-	OnError func(w http.ResponseWriter, r *http.Request, e error)
 }
 
 type routeContextKey struct{}
@@ -221,14 +219,7 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request, route *Ro
 	results, err := req.Do(ctx)
 
 	if err != nil {
-		if s.OnError != nil {
-			s.OnError(w, r, err)
-			return
-		} else {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("500 internal server error"))
-			return
-		}
+		panic(err)
 	}
 
 	resBuilder := newResponseBuilder(*s, w)


### PR DESCRIPTION
Since migrating to use middleware, Voltron should no longer attempt to
handle all critical paths such as error handling since API consumers can
now easily wrap the entire request using a recovery middleware.

This removes the `OnError` function on the `Server` struct and now
`panic`s when an error is encountered instead of calling the callback.
