### PR TITLE
Add multiplexer.Tripper interface

### DIFF
--- a/pkg/middleware/logging/logging.go
+++ b/pkg/middleware/logging/logging.go
@@ -1,0 +1,85 @@
+package logging
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/blakewilliams/viewproxy"
+	"github.com/blakewilliams/viewproxy/pkg/multiplexer"
+)
+
+type logger interface {
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+}
+
+type ResponseWrapper struct {
+	responseWriter http.ResponseWriter
+	StatusCode     int
+}
+
+func (rw *ResponseWrapper) Header() http.Header {
+	return rw.responseWriter.Header()
+}
+
+func (rw *ResponseWrapper) Write(p []byte) (int, error) {
+	return rw.responseWriter.Write(p)
+}
+
+func (rw *ResponseWrapper) WriteHeader(statusCode int) {
+	rw.StatusCode = statusCode
+	rw.responseWriter.WriteHeader(statusCode)
+}
+
+func LoggingMiddleware(server *viewproxy.Server, l logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			route := viewproxy.RouteFromContext(r.Context())
+
+			if route != nil {
+				l.Printf("Handling %s", r.URL.Path)
+			} else if server.PassThrough {
+				l.Printf("Proxying %s", r.URL.Path)
+			} else {
+				l.Printf("Proxying is disabled and no route matches %s", r.URL.Path)
+			}
+
+			wrapper := &ResponseWrapper{responseWriter: w, StatusCode: 200} // use default 200 to initialize
+			next.ServeHTTP(wrapper, r)
+
+			duration := time.Since(start)
+
+			if route != nil {
+				l.Printf("Rendered %d in %dms for %s", wrapper.StatusCode, duration.Milliseconds(), r.URL.Path)
+			} else if server.PassThrough {
+				l.Printf("Proxied %d in %dms for %s", wrapper.StatusCode, duration.Milliseconds(), r.URL.Path)
+			}
+		})
+	}
+}
+
+type logTripper struct {
+	logger  logger
+	tripper multiplexer.Tripper
+}
+
+func NewLogTripper(l logger, tripper multiplexer.Tripper) multiplexer.Tripper {
+	return &logTripper{logger: l, tripper: tripper}
+}
+
+func (t *logTripper) Request(r *http.Request) (*http.Response, error) {
+	start := time.Now()
+	res, err := t.tripper.Request(r)
+	duration := time.Since(start)
+	fragment := viewproxy.FragmentFromContext(r.Context())
+
+	// If fragment is nil, we are proxying
+	if fragment != nil {
+		t.logger.Printf("Fragment %d in %dms for %s", res.StatusCode, duration.Milliseconds(), fragment.Url)
+	} else {
+		t.logger.Printf("Proxy request %d in %dms for %s", res.StatusCode, duration.Milliseconds(), r.URL)
+	}
+
+	return res, err
+}

--- a/pkg/middleware/logging/logging_test.go
+++ b/pkg/middleware/logging/logging_test.go
@@ -37,7 +37,7 @@ func TestLoggingMiddleware(t *testing.T) {
 
 	log := &SliceLogger{logs: make([]string, 0)}
 	viewProxyServer.AroundRequest = func(handler http.Handler) http.Handler {
-		handler = LoggingMiddleware(viewProxyServer, log)(handler)
+		handler = Middleware(viewProxyServer, log)(handler)
 
 		return handler
 	}
@@ -135,6 +135,9 @@ func startTargetServer() *httptest.Server {
 			w.Write([]byte("<body>"))
 		} else if r.URL.Path == "/body" {
 			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(fmt.Sprintf("hello %s", params.Get("name"))))
+		} else if r.URL.Path == "/boom" {
+			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(fmt.Sprintf("hello %s", params.Get("name"))))
 		} else {
 			w.WriteHeader(http.StatusNotFound)

--- a/pkg/middleware/logging/logging_test.go
+++ b/pkg/middleware/logging/logging_test.go
@@ -1,0 +1,147 @@
+package logging
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/blakewilliams/viewproxy"
+	"github.com/blakewilliams/viewproxy/pkg/multiplexer"
+	"github.com/stretchr/testify/assert"
+)
+
+type SliceLogger struct {
+	logs []string
+}
+
+func (l *SliceLogger) Print(v ...interface{}) {
+	l.logs = append(l.logs, fmt.Sprint(v...))
+}
+
+func (l *SliceLogger) Printf(line string, args ...interface{}) {
+	l.logs = append(l.logs, fmt.Sprintf(line, args...))
+}
+
+func TestLoggingMiddleware(t *testing.T) {
+	targetServer := startTargetServer()
+	viewProxyServer := viewproxy.NewServer(targetServer.URL)
+	viewProxyServer.PassThrough = true
+
+	layout := viewproxy.NewFragment("/layouts/test_layout")
+	fragments := []*viewproxy.Fragment{
+		viewproxy.NewFragment("body"),
+	}
+	viewProxyServer.Get("/hello/:name", layout, fragments)
+
+	log := &SliceLogger{logs: make([]string, 0)}
+	viewProxyServer.AroundRequest = func(handler http.Handler) http.Handler {
+		handler = LoggingMiddleware(viewProxyServer, log)(handler)
+
+		return handler
+	}
+
+	// Regular request with fragments
+	r := httptest.NewRequest("GET", "/hello/world", nil)
+	w := httptest.NewRecorder()
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
+	resp := w.Result()
+	assert.Equal(t, 200, resp.StatusCode)
+
+	assert.Equal(t, "Handling /hello/world", log.logs[0])
+	assert.Regexp(t, regexp.MustCompile(`Rendered 200 in \d+ms for /hello/world`), log.logs[1])
+
+	// Proxying request
+	r = httptest.NewRequest("GET", "/fake", nil)
+	w = httptest.NewRecorder()
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
+	resp = w.Result()
+	assert.Equal(t, 404, resp.StatusCode)
+
+	assert.Equal(t, "Proxying /fake", log.logs[2])
+	assert.Regexp(t, regexp.MustCompile(`Proxied 404 in \d+ms for /fake`), log.logs[3])
+
+	// Proxying disabled
+	viewProxyServer.PassThrough = false
+	r = httptest.NewRequest("GET", "/fake", nil)
+	w = httptest.NewRecorder()
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
+	resp = w.Result()
+	assert.Equal(t, 404, resp.StatusCode)
+
+	assert.Equal(t, "Proxying is disabled and no route matches /fake", log.logs[4])
+}
+
+func TestLogTripperFragments(t *testing.T) {
+	targetServer := startTargetServer()
+	viewProxyServer := viewproxy.NewServer(targetServer.URL)
+	viewProxyServer.PassThrough = true
+
+	layout := viewproxy.NewFragment("/layouts/test_layout")
+	fragments := []*viewproxy.Fragment{
+		viewproxy.NewFragment("body"),
+	}
+	viewProxyServer.Get("/hello/:name", layout, fragments)
+
+	log := &SliceLogger{logs: make([]string, 0)}
+	viewProxyServer.MultiplexerTripper = NewLogTripper(log, multiplexer.NewStandardTripper(&http.Client{}))
+
+	r := httptest.NewRequest("GET", "/hello/world", nil)
+	w := httptest.NewRecorder()
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
+	resp := w.Result()
+	assert.Equal(t, 200, resp.StatusCode)
+
+	fmt.Println(log.logs)
+
+	assert.Regexp(t, regexp.MustCompile(`Fragment 200 in \d+ms for http:\/\/.*`), log.logs[0])
+	assert.Regexp(t, regexp.MustCompile(`Fragment 200 in \d+ms for http:\/\/.*`), log.logs[1])
+}
+
+func TestLogTripperProxy(t *testing.T) {
+	targetServer := startTargetServer()
+	viewProxyServer := viewproxy.NewServer(targetServer.URL)
+	viewProxyServer.PassThrough = true
+
+	layout := viewproxy.NewFragment("/layouts/test_layout")
+	fragments := []*viewproxy.Fragment{
+		viewproxy.NewFragment("body"),
+	}
+	viewProxyServer.Get("/hello/:name", layout, fragments)
+
+	log := &SliceLogger{logs: make([]string, 0)}
+	viewProxyServer.MultiplexerTripper = NewLogTripper(log, multiplexer.NewStandardTripper(&http.Client{}))
+
+	r := httptest.NewRequest("GET", "/fake", nil)
+	w := httptest.NewRecorder()
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
+	resp := w.Result()
+	assert.Equal(t, 404, resp.StatusCode)
+
+	fmt.Println(log.logs)
+	assert.Regexp(t, regexp.MustCompile(`Proxy request 404 in \d+ms for http:\/\/.*`), log.logs[0])
+}
+
+func startTargetServer() *httptest.Server {
+	instance := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := r.URL.Query()
+
+		if r.URL.Path == "/layouts/test_layout" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("<html><view-proxy-content></view-proxy-content></html>"))
+		} else if r.URL.Path == "/header" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("<body>"))
+		} else if r.URL.Path == "/body" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(fmt.Sprintf("hello %s", params.Get("name"))))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte("404 not found"))
+		}
+	})
+
+	testServer := httptest.NewServer(instance)
+	return testServer
+}

--- a/pkg/multiplexer/fragment.go
+++ b/pkg/multiplexer/fragment.go
@@ -1,0 +1,23 @@
+package multiplexer
+
+import "context"
+
+type FragmentContextKey struct{}
+
+type Fragment struct {
+	Url         string
+	Metadata    map[string]string
+	timingLabel string
+}
+
+func FragmentFromContext(ctx context.Context) *Fragment {
+	if ctx == nil {
+		return nil
+	}
+
+	if fragment := ctx.Value(FragmentContextKey{}); fragment != nil {
+		fragment := fragment.(Fragment)
+		return &fragment
+	}
+	return nil
+}

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -16,7 +16,7 @@ func TestRequestDoReturnsMultipleResponsesInOrder(t *testing.T) {
 	server := startServer()
 	urls := []string{"http://localhost:9990?fragment=header", "http://localhost:9990?fragment=footer"}
 
-	r := NewRequest()
+	r := NewRequest(NewStandardTripper(&http.Client{}))
 	r.WithFragment(urls[0], make(map[string]string), "")
 	r.WithFragment(urls[1], make(map[string]string), "")
 	r.Timeout = defaultTimeout
@@ -46,7 +46,7 @@ func TestRequestDoForwardsHeaders(t *testing.T) {
 
 	fakeHTTPRequest := &http.Request{Header: headers}
 
-	r := NewRequest()
+	r := NewRequest(NewStandardTripper(&http.Client{}))
 	r.WithFragment("http://localhost:9990?fragment=echo_headers", make(map[string]string), "")
 	r.WithHeadersFromRequest(fakeHTTPRequest)
 	r.Timeout = defaultTimeout
@@ -62,7 +62,7 @@ func TestRequestDoForwardsHeaders(t *testing.T) {
 func TestFetch404ReturnsError(t *testing.T) {
 	server := startServer()
 
-	r := NewRequest()
+	r := NewRequest(NewStandardTripper(&http.Client{}))
 	r.WithFragment("http://localhost:9990/wowomg", make(map[string]string), "")
 	r.Timeout = defaultTimeout
 	results, err := r.Do(context.TODO())
@@ -81,7 +81,7 @@ func TestFetch500ReturnsError(t *testing.T) {
 	start := time.Now()
 
 	urls := []string{"http://localhost:9990/?fragment=oops", "http://localhost:9990?fragment=slow"}
-	r := NewRequest()
+	r := NewRequest(NewStandardTripper(&http.Client{}))
 	r.WithFragment(urls[0], make(map[string]string), "")
 	r.WithFragment(urls[1], make(map[string]string), "")
 	results, err := r.Do(context.TODO())
@@ -102,7 +102,7 @@ func TestFetchTimeout(t *testing.T) {
 	server := startServer()
 	start := time.Now()
 
-	r := NewRequest()
+	r := NewRequest(NewStandardTripper(&http.Client{}))
 	r.WithFragment("http://localhost:9990?fragment=slow", make(map[string]string), "")
 	r.Timeout = time.Duration(100) * time.Millisecond
 	_, err := r.Do(context.Background())
@@ -118,7 +118,7 @@ func TestCanIgnoreNon2xxErrors(t *testing.T) {
 	server := startServer()
 
 	ctx := context.Background()
-	r := NewRequest()
+	r := NewRequest(NewStandardTripper(&http.Client{}))
 	r.WithFragment("http://localhost:9990?fragment=slow", make(map[string]string), "")
 	r.Timeout = time.Duration(100) * time.Millisecond
 	r.Non2xxErrors = false

--- a/pkg/multiplexer/tripper.go
+++ b/pkg/multiplexer/tripper.go
@@ -6,21 +6,21 @@ type Tripper interface {
 	Request(r *http.Request) (*http.Response, error)
 }
 
-type StandardTripper struct {
+type standardTripper struct {
 	client *http.Client
 }
 
 // Creates a new instance of a Tripper. The passed in client is modified to
 // have no cookie jar and to not follow redirects.
-func NewStandardTripper(client *http.Client) *StandardTripper {
+func NewStandardTripper(client *http.Client) Tripper {
 	client.Jar = nil
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
 
-	return &StandardTripper{client: client}
+	return &standardTripper{client: client}
 }
 
-func (t *StandardTripper) Request(r *http.Request) (*http.Response, error) {
+func (t *standardTripper) Request(r *http.Request) (*http.Response, error) {
 	return t.client.Do(r)
 }

--- a/pkg/multiplexer/tripper.go
+++ b/pkg/multiplexer/tripper.go
@@ -1,0 +1,26 @@
+package multiplexer
+
+import "net/http"
+
+type Tripper interface {
+	Request(r *http.Request) (*http.Response, error)
+}
+
+type StandardTripper struct {
+	client *http.Client
+}
+
+// Creates a new instance of a Tripper. The passed in client is modified to
+// have no cookie jar and to not follow redirects.
+func NewStandardTripper(client *http.Client) *StandardTripper {
+	client.Jar = nil
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	return &StandardTripper{client: client}
+}
+
+func (t *StandardTripper) Request(r *http.Request) (*http.Response, error) {
+	return t.client.Do(r)
+}

--- a/server_test.go
+++ b/server_test.go
@@ -114,7 +114,7 @@ func TestHealthCheck(t *testing.T) {
 	r := httptest.NewRequest("GET", "/_ping", nil)
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 
@@ -141,7 +141,7 @@ func TestQueryParamForwardingServer(t *testing.T) {
 	r := httptest.NewRequest("GET", "/hello/world?important=true&name=override", nil)
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 
@@ -162,7 +162,7 @@ func TestPassThroughEnabled(t *testing.T) {
 	r := httptest.NewRequest("GET", "/oops", nil)
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 	body, err := ioutil.ReadAll(resp.Body)
@@ -179,7 +179,7 @@ func TestPassThroughDisabled(t *testing.T) {
 	r := httptest.NewRequest("GET", "/hello/world", nil)
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 	body, err := ioutil.ReadAll(resp.Body)
@@ -213,7 +213,7 @@ func TestPassThroughSetsCorrectHeaders(t *testing.T) {
 	r.RemoteAddr = "localhost:1"
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	select {
 	case <-done:
@@ -248,7 +248,7 @@ func TestPassThroughPostRequest(t *testing.T) {
 	r := httptest.NewRequest("POST", "/hello/world", strings.NewReader("hello"))
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	select {
 	case <-done:
@@ -292,7 +292,7 @@ func TestFragmentSendsVerifiableHmacWhenSet(t *testing.T) {
 	r := httptest.NewRequest("GET", "/hello/world", strings.NewReader("hello"))
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	<-done
 
@@ -329,7 +329,7 @@ func TestFragmentSetsCorrectHeaders(t *testing.T) {
 	r.RemoteAddr = "localhost:1"
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	<-layoutDone
 	<-fragmentDone
@@ -372,7 +372,7 @@ func TestSupportsGzip(t *testing.T) {
 	r.Header.Set("Accept-Encoding", "gzip")
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 
@@ -406,7 +406,7 @@ func TestAroundRequestCallback(t *testing.T) {
 	r := httptest.NewRequest("GET", "/hello/world", nil)
 	r.RemoteAddr = "192.168.1.1"
 
-	server.createHandler().ServeHTTP(w, r)
+	server.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 
@@ -446,7 +446,7 @@ func TestOnErrorHandler(t *testing.T) {
 	fakeRequest := httptest.NewRequest("GET", "/hello/world", nil)
 	fakeRequest.RemoteAddr = "192.168.1.1"
 
-	server.createHandler().ServeHTTP(fakeWriter, fakeRequest)
+	server.CreateHandler().ServeHTTP(fakeWriter, fakeRequest)
 
 	assert.Equal(t, "true", fakeWriter.Header().Get("x-viewproxy"))
 
@@ -486,7 +486,7 @@ func TestRoundTripperContext(t *testing.T) {
 	r := httptest.NewRequest("GET", "/hello/world?important=true&name=override", nil)
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 


### PR DESCRIPTION
This adds a transport interface that allows consumers of viewproxy to
provide their own logic for fetching fragments.

Instead of providing completely paved paths with logging and
instrumentation this will allow consumers to build their own low-level
logging, instrumentation, http request logic, and more.

A default tripper implementation is provided that delegates to an
`http.Client{}`.

Additionally, the `route`, and `fragment` for the request is provided in
the `request.Context()` so consumers can log or instrument individual
requests.
