### PR TITLE
Change port config to use full address

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -16,7 +17,7 @@ import (
 func main() {
 	target := getTarget()
 	server := viewproxy.NewServer(target)
-	server.Port = getPort()
+	server.Addr = fmt.Sprintf("localhost:%d", getPort())
 	server.ProxyTimeout = time.Duration(5) * time.Second
 	server.Logger = buildLogger()
 	server.DefaultPageTitle = "Demo app"

--- a/server.go
+++ b/server.go
@@ -31,7 +31,7 @@ type logger interface {
 }
 
 type Server struct {
-	Port             int
+	Addr             string
 	ProxyTimeout     time.Duration
 	routes           []Route
 	target           string
@@ -67,7 +67,7 @@ func NewServer(target string) *Server {
 		DefaultPageTitle:   "viewproxy",
 		MultiplexerTripper: multiplexer.NewStandardTripper(&http.Client{}),
 		Logger:             log.Default(),
-		Port:               3005,
+		Addr:               "localhost:3005",
 		ProxyTimeout:       time.Duration(10) * time.Second,
 		PassThrough:        false,
 		AroundRequest:      func(h http.Handler) http.Handler { return h },
@@ -318,14 +318,14 @@ func (s *Server) ListenAndServe() error {
 	s.IgnoreHeader("Content-Length")
 
 	s.httpServer = &http.Server{
-		Addr:           fmt.Sprintf(":%d", s.Port),
+		Addr:           s.Addr,
 		Handler:        s.CreateHandler(),
 		ReadTimeout:    10 * time.Second,
 		WriteTimeout:   10 * time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}
 
-	s.Logger.Printf("Listening on port %d\n", s.Port)
+	s.Logger.Printf("Listening on %v", s.Addr)
 
 	return s.httpServer.ListenAndServe()
 }

--- a/server_test.go
+++ b/server_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 
 func TestServer(t *testing.T) {
 	viewProxyServer := NewServer(targetServer.URL)
-	viewProxyServer.Port = 9998
+	viewProxyServer.Addr = "localhost:9998"
 	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
 
 	viewProxyServer.IgnoreHeader("etag")


### PR DESCRIPTION
Previously we were only letting the server port be configured and bound the server address to `:3005`.

This pull request changes it so the full server address can be configured to allow bindings like `localhost:3005`.

This allows the tests on macos to skip these warnings when binding to `:PORT` without a host name.

<img width="451" alt="Screen Shot 2021-07-26 at 11 38 22 AM" src="https://user-images.githubusercontent.com/671378/127041074-0fbcd3bf-928d-463b-814b-e343c1a366ea.png">
