### PR TITLE
Expose Serve API that takes a listener

### DIFF
--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -163,7 +163,7 @@ func startServer() *http.Server {
 		}
 	})
 
-	testServer := &http.Server{Addr: ":9990", Handler: instance}
+	testServer := &http.Server{Addr: "localhost:9990", Handler: instance}
 	go func() {
 		if err := testServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			panic(err)

--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -312,6 +313,18 @@ func FragmentFromContext(ctx context.Context) *multiplexer.Fragment {
 }
 
 func (s *Server) ListenAndServe() error {
+	return s.configureServer(func() error {
+		return s.httpServer.ListenAndServe()
+	})
+}
+
+func (s *Server) Serve(listener net.Listener) error {
+	return s.configureServer(func() error {
+		return s.httpServer.Serve(listener)
+	})
+}
+
+func (s *Server) configureServer(serveFn func() error) error {
 	shutdownTracing, err := tracing.Instrument(s.tracingConfig, s.Logger)
 	if err != nil {
 		log.Printf("Error instrumenting tracing: %v", err)
@@ -331,5 +344,5 @@ func (s *Server) ListenAndServe() error {
 
 	s.Logger.Printf("Listening on %v", s.Addr)
 
-	return s.httpServer.ListenAndServe()
+	return serveFn()
 }

--- a/server.go
+++ b/server.go
@@ -314,12 +314,14 @@ func FragmentFromContext(ctx context.Context) *multiplexer.Fragment {
 
 func (s *Server) ListenAndServe() error {
 	return s.configureServer(func() error {
+		s.Logger.Printf("Listening on %v", s.Addr)
 		return s.httpServer.ListenAndServe()
 	})
 }
 
 func (s *Server) Serve(listener net.Listener) error {
 	return s.configureServer(func() error {
+		s.Logger.Printf("Listening on %v", listener.Addr())
 		return s.httpServer.Serve(listener)
 	})
 }
@@ -341,8 +343,6 @@ func (s *Server) configureServer(serveFn func() error) error {
 		WriteTimeout:   10 * time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}
-
-	s.Logger.Printf("Listening on %v", s.Addr)
 
 	return serveFn()
 }


### PR DESCRIPTION
This pull request adds a Serve API that takes a `net.Listener`.

This will allow callers to use it directly instead of `ListenAndServe` when they want to manage/configure their own listeners.