### PR TITLE
Add header with original request path to fragment requests

### DIFF
--- a/server.go
+++ b/server.go
@@ -16,6 +16,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	HeaderViewProxyOriginalPath = "X-Viewproxy-Original-Path"
+)
+
 // Re-export ResultError for convenience
 type ResultError = multiplexer.ResultError
 
@@ -220,6 +224,7 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request, route *Ro
 	}
 
 	req.WithHeadersFromRequest(r)
+	req.Header.Add(HeaderViewProxyOriginalPath, r.URL.RequestURI())
 	results, err := req.Do(ctx)
 
 	if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -311,6 +311,7 @@ func TestFragmentSetsCorrectHeaders(t *testing.T) {
 			defer close(fragmentDone)
 			w.Header().Set("Server-Timing", "db;dur=34")
 		}
+		assert.Equal(t, r.Header.Get(HeaderViewProxyOriginalPath), "/hello/world?foo=bar")
 		assert.Equal(t, "", r.Header.Get("Keep-Alive"), "Expected Keep-Alive to be filtered")
 		assert.NotEqual(t, "", r.Header.Get("X-Forwarded-For"))
 		assert.Equal(t, "localhost:1", r.Header.Get("X-Forwarded-Host"))
@@ -324,7 +325,7 @@ func TestFragmentSetsCorrectHeaders(t *testing.T) {
 	fragment.TimingLabel = "bar"
 	viewProxyServer.Get("/hello/:name", layout, []*Fragment{fragment})
 
-	r := httptest.NewRequest("GET", "/hello/world", strings.NewReader("hello"))
+	r := httptest.NewRequest("GET", "/hello/world?foo=bar", strings.NewReader("hello"))
 	r.Host = "localhost:1" // go deletes the Host header and sets the Host field
 	r.RemoteAddr = "localhost:1"
 	w := httptest.NewRecorder()


### PR DESCRIPTION
Currently the target application doesn't know the original request path
that triggered it to run.

This resolves the issue by sending the original request path to each
layout/fragment request via the "X-Viewproxy-Original-Path" header.
