### PR TITLE
Preserve forwarded proto and host headers

### DIFF
--- a/pkg/multiplexer/headers.go
+++ b/pkg/multiplexer/headers.go
@@ -42,8 +42,13 @@ func HeadersFromRequest(req *http.Request) http.Header {
 	// go strips the host header for some reason
 	// https://github.com/golang/go/blob/master/src/net/http/server.go#L999
 	newHeaders.Set("Host", req.Host)
-	newHeaders.Set("X-Forwarded-Host", req.Host)
-	newHeaders.Set("X-Forwarded-Proto", req.Proto)
+
+	if val := newHeaders.Get("X-Forwarded-Host"); val == "" {
+		newHeaders.Set("X-Forwarded-Host", req.Host)
+	}
+	if val := newHeaders.Get("X-Forwarded-Proto"); val == "" {
+		newHeaders.Set("X-Forwarded-Proto", req.Proto)
+	}
 
 	return newHeaders
 }

--- a/pkg/multiplexer/headers_test.go
+++ b/pkg/multiplexer/headers_test.go
@@ -1,0 +1,42 @@
+package multiplexer
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreservesForwardedHeaders(t *testing.T) {
+	headers := http.Header{}
+	headers.Add("X-Forwarded-For", "1.2.3.4")
+	headers.Add("X-Forwarded-Host", "example.com")
+	headers.Add("X-Forwarded-Proto", "httpz")
+	fakeHTTPRequest := &http.Request{Header: headers}
+	fakeHTTPRequest.RemoteAddr = "1.3.5.7"
+
+	newHeaders := HeadersFromRequest(fakeHTTPRequest)
+
+	// append X-Forwarded-For
+	assert.Equal(t, "1.2.3.4, 1.3.5.7", newHeaders.Get("X-Forwarded-For"))
+
+	// preserve X-Forwarded-Host and X-Forwarded-Proto
+	assert.Equal(t, "example.com", newHeaders.Get("X-Forwarded-Host"))
+	assert.Equal(t, "httpz", newHeaders.Get("X-Forwarded-Proto"))
+}
+
+func TestSetsDefaultForwardedHeaders(t *testing.T) {
+	fakeHTTPRequest := &http.Request{}
+	fakeHTTPRequest.Proto = "httpz"
+	fakeHTTPRequest.Host = "example.com"
+	fakeHTTPRequest.RemoteAddr = "1.3.5.7"
+
+	newHeaders := HeadersFromRequest(fakeHTTPRequest)
+
+	// append X-Forwarded-For
+	assert.Equal(t, "1.3.5.7", newHeaders.Get("X-Forwarded-For"))
+
+	// set default X-Forwarded-Host and X-Forwarded-Proto
+	assert.Equal(t, "example.com", newHeaders.Get("X-Forwarded-Host"))
+	assert.Equal(t, "httpz", newHeaders.Get("X-Forwarded-Proto"))
+}


### PR DESCRIPTION
This preserves forwarded proto and host headers to handle the case where viewproxy is itself behind one or more proxies.