### PR TITLE
Filter result error messages using secret filter

### DIFF
--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blakewilliams/viewproxy/pkg/secretfilter"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -29,6 +30,7 @@ type Request struct {
 	HmacSecret   string
 	Non2xxErrors bool
 	Tripper      Tripper
+	SecretFilter secretfilter.Filter
 }
 
 func NewRequest(tripper Tripper) *Request {
@@ -184,11 +186,7 @@ func (r *Request) fetchUrl(ctx context.Context, method string, url string, heade
 	}
 
 	if r.Non2xxErrors && (resp.StatusCode < 200 || resp.StatusCode > 299) {
-		err := &ResultError{
-			Result: result,
-		}
-
-		return nil, err
+		return nil, newResultError(r, result)
 	}
 
 	return result, nil

--- a/pkg/multiplexer/result.go
+++ b/pkg/multiplexer/result.go
@@ -8,14 +8,18 @@ import (
 
 type ResultError struct {
 	Result *Result
+	msg    string
+}
+
+func newResultError(req *Request, res *Result) *ResultError {
+	safeUrl := req.SecretFilter.FilterURLString(res.Url)
+	msg := fmt.Sprintf("status: %d url: %s", res.StatusCode, safeUrl)
+
+	return &ResultError{Result: res, msg: msg}
 }
 
 func (re *ResultError) Error() string {
-	return fmt.Sprintf(
-		"status: %d url: %s",
-		re.Result.StatusCode,
-		re.Result.Url,
-	)
+	return re.msg
 }
 
 type Result struct {


### PR DESCRIPTION
This pull request uses the `SecretFilter` to filter the URL included in the `ResultError` message.

Refs #52 