### PR TITLE
Remove title replacement functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ import "github.com/blakewilliams/viewproxy"
 server := viewproxy.NewServer(target)
 server.Port = 3005
 server.ProxyTimeout = time.Duration(5) * time.Second
-server.DefaultPageTitle = "Demo app"
 server.IgnoreHeader("etag")
 server.PassThrough = true
 

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -20,7 +20,6 @@ func main() {
 	server.Addr = fmt.Sprintf("localhost:%d", getPort())
 	server.ProxyTimeout = time.Duration(5) * time.Second
 	server.Logger = buildLogger()
-	server.DefaultPageTitle = "Demo app"
 	server.IgnoreHeader("etag")
 	server.PassThrough = true
 

--- a/response_builder.go
+++ b/response_builder.go
@@ -40,25 +40,15 @@ func (rb *responseBuilder) SetHeaders(headers http.Header, results []*multiplexe
 
 func (rb *responseBuilder) SetFragments(results []*multiplexer.Result) {
 	var contentHtml []byte
-	var pageTitle string
 
 	for _, result := range results {
 		contentHtml = append(contentHtml, result.Body...)
-
-		if result.HttpResponse.Header.Get("X-View-Proxy-Title") != "" {
-			pageTitle = result.HttpResponse.Header.Get("X-View-Proxy-Title")
-		}
-	}
-
-	if pageTitle == "" {
-		pageTitle = rb.server.DefaultPageTitle
 	}
 
 	if len(rb.body) == 0 {
 		rb.body = contentHtml
 	} else {
 		outputHtml := bytes.Replace(rb.body, []byte("<view-proxy-content></view-proxy-content>"), contentHtml, 1)
-		outputHtml = bytes.Replace(outputHtml, []byte("{{{VIEW_PROXY_PAGE_TITLE}}}"), []byte(pageTitle), 1)
 
 		rb.body = outputHtml
 	}

--- a/server.go
+++ b/server.go
@@ -37,16 +37,15 @@ type logger interface {
 }
 
 type Server struct {
-	Addr             string
-	ProxyTimeout     time.Duration
-	routes           []Route
-	target           string
-	httpServer       *http.Server
-	Logger           logger
-	DefaultPageTitle string
-	ignoreHeaders    map[string]bool
-	PassThrough      bool
-	SecretFilter     secretfilter.Filter
+	Addr          string
+	ProxyTimeout  time.Duration
+	routes        []Route
+	target        string
+	httpServer    *http.Server
+	Logger        logger
+	ignoreHeaders map[string]bool
+	PassThrough   bool
+	SecretFilter  secretfilter.Filter
 	// Sets the secret used to generate an HMAC that can be used by the target
 	// server to validate that a request came from viewproxy.
 	//
@@ -71,7 +70,6 @@ type parametersContextKey struct{}
 
 func NewServer(target string) *Server {
 	return &Server{
-		DefaultPageTitle:   "viewproxy",
 		MultiplexerTripper: multiplexer.NewStandardTripper(&http.Client{}),
 		Logger:             log.Default(),
 		SecretFilter:       secretfilter.New(),


### PR DESCRIPTION
While using this library we've determined that the title replacement
functionality via headers isn't currently necessary.
