### PR TITLE
Use Set instead of Add for original path header

### DIFF
--- a/server.go
+++ b/server.go
@@ -231,7 +231,7 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request, route *Ro
 	}
 
 	req.WithHeadersFromRequest(r)
-	req.Header.Add(HeaderViewProxyOriginalPath, r.URL.RequestURI())
+	req.Header.Set(HeaderViewProxyOriginalPath, r.URL.RequestURI())
 	results, err := req.Do(ctx)
 
 	if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -328,6 +328,7 @@ func TestFragmentSetsCorrectHeaders(t *testing.T) {
 	r := httptest.NewRequest("GET", "/hello/world?foo=bar", strings.NewReader("hello"))
 	r.Host = "localhost:1" // go deletes the Host header and sets the Host field
 	r.RemoteAddr = "localhost:1"
+	r.Header.Add(HeaderViewProxyOriginalPath, "/fake/path")
 	w := httptest.NewRecorder()
 
 	viewProxyServer.CreateHandler().ServeHTTP(w, r)


### PR DESCRIPTION
This pull request tweaks the handling of `X-Viewproxy-Original-Path` to use `Set` instead of `Add` so that the header value is set once and only contains the value generated by `viewproxy`, not a value set on the original request.