### PR TITLE
Forward http.Server shutdown error in viewproxy shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -147,8 +147,8 @@ func (s *Server) loadRoutes(routeEntries []configRouteEntry) error {
 	return nil
 }
 
-func (s *Server) Shutdown(ctx context.Context) {
-	s.httpServer.Shutdown(ctx)
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.httpServer.Shutdown(ctx)
 }
 
 func (s *Server) Close() {


### PR DESCRIPTION
This will allow consumers of the API to determine why a shutdown failed and
react to it.
