### PR TITLE
Allow read/write timeout to be configured

### DIFF
--- a/server.go
+++ b/server.go
@@ -40,6 +40,8 @@ type logger interface {
 type Server struct {
 	Addr          string
 	ProxyTimeout  time.Duration
+	ReadTimeout   time.Duration
+	WriteTimeout  time.Duration
 	routes        []Route
 	target        string
 	httpServer    *http.Server
@@ -69,6 +71,8 @@ type Server struct {
 type routeContextKey struct{}
 type parametersContextKey struct{}
 
+const defaultTimeout = 10 * time.Second
+
 // NewServer returns a new Server that will make requests to the given target argument.
 func NewServer(target string) *Server {
 	return &Server{
@@ -76,7 +80,9 @@ func NewServer(target string) *Server {
 		Logger:             log.Default(),
 		SecretFilter:       secretfilter.New(),
 		Addr:               "localhost:3005",
-		ProxyTimeout:       time.Duration(10) * time.Second,
+		ProxyTimeout:       defaultTimeout,
+		ReadTimeout:        defaultTimeout,
+		WriteTimeout:       defaultTimeout,
 		PassThrough:        false,
 		AroundRequest:      func(h http.Handler) http.Handler { return h },
 		target:             target,
@@ -373,8 +379,8 @@ func (s *Server) configureServer(serveFn func() error) error {
 	s.httpServer = &http.Server{
 		Addr:           s.Addr,
 		Handler:        s.CreateHandler(),
-		ReadTimeout:    10 * time.Second,
-		WriteTimeout:   10 * time.Second,
+		ReadTimeout:    s.ReadTimeout,
+		WriteTimeout:   s.WriteTimeout,
 		MaxHeaderBytes: 1 << 20,
 	}
 

--- a/server.go
+++ b/server.go
@@ -38,9 +38,12 @@ type logger interface {
 }
 
 type Server struct {
-	Addr          string
-	ProxyTimeout  time.Duration
-	ReadTimeout   time.Duration
+	Addr string
+	// Sets the timeout for requests made to the target
+	ProxyTimeout time.Duration
+	// Sets the maximum duration for reading the entire request, including the body
+	ReadTimeout time.Duration
+	// Sets the maximum duration before timing out writes of the response
 	WriteTimeout  time.Duration
 	routes        []Route
 	target        string

--- a/server.go
+++ b/server.go
@@ -39,7 +39,7 @@ type logger interface {
 
 type Server struct {
 	Addr string
-	// Sets the timeout for requests made to the target
+	// Sets the timeout for requests made to the target server
 	ProxyTimeout time.Duration
 	// Sets the maximum duration for reading the entire request, including the body
 	ReadTimeout time.Duration

--- a/server.go
+++ b/server.go
@@ -39,7 +39,7 @@ type logger interface {
 
 type Server struct {
 	Addr string
-	// Sets the timeout for requests made to the target server
+	// Sets the maximum duration for requests made to the target server
 	ProxyTimeout time.Duration
 	// Sets the maximum duration for reading the entire request, including the body
 	ReadTimeout time.Duration


### PR DESCRIPTION
This pull request adds `ReadTimeout` and `WriteTimeout` configurations to be set by consumers.