### PR TITLE
Filter url errors using secretfilter package

### DIFF
--- a/pkg/secretfilter/secretfilter.go
+++ b/pkg/secretfilter/secretfilter.go
@@ -11,6 +11,7 @@ type Filter interface {
 	FilterURL(url *url.URL) *url.URL
 	FilterURLString(url string) string
 	FilterQueryParams(params url.Values) url.Values
+	FilterURLError(err *url.Error) *url.Error
 }
 
 type mapKey struct{}
@@ -74,4 +75,12 @@ func (l *secretFilter) FilterQueryParams(query url.Values) url.Values {
 	}
 
 	return filteredQueryParams
+}
+
+func (l *secretFilter) FilterURLError(err *url.Error) *url.Error {
+	return &url.Error{
+		Op:  err.Op,
+		URL: l.FilterURLString(err.URL),
+		Err: err.Err,
+	}
 }

--- a/pkg/secretfilter/secretfilter_test.go
+++ b/pkg/secretfilter/secretfilter_test.go
@@ -1,6 +1,7 @@
 package secretfilter
 
 import (
+	"io"
 	"net/url"
 	"testing"
 
@@ -102,4 +103,19 @@ func TestSecretFilter_FilterQueryParams(t *testing.T) {
 			require.Equal(t, tc.want, filter.FilterQueryParams(tc.input))
 		})
 	}
+}
+
+func TestSecretFilter_FilterUrlError(t *testing.T) {
+	original := &url.Error{
+		Op:  "Get",
+		Err: io.EOF,
+		URL: "http://localhost/foo?a=1",
+	}
+
+	filter := New()
+	filtered := filter.FilterURLError(original)
+
+	require.Equal(t, "http://localhost/foo?a=FILTERED", filtered.URL)
+	require.Equal(t, "Get", filtered.Op)
+	require.Equal(t, io.EOF, filtered.Err)
 }


### PR DESCRIPTION
This pull request runs all `url.Error` request errors through the secretfilter.

This prevents them from surfacing unfiltered values.