### PR TITLE
Migrate custom proxy to httputil.ReverseProxy

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -17,7 +17,12 @@ import (
 
 func main() {
 	target := getTarget()
-	server := viewproxy.NewServer(target, viewproxy.WithPassThrough(target))
+	server, err := viewproxy.NewServer(target, viewproxy.WithPassThrough(target))
+
+	if err != nil {
+		panic(err)
+	}
+
 	server.Addr = fmt.Sprintf("localhost:%d", getPort())
 	server.ProxyTimeout = time.Duration(5) * time.Second
 	server.Logger = buildLogger()

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -17,12 +17,11 @@ import (
 
 func main() {
 	target := getTarget()
-	server := viewproxy.NewServer(target)
+	server := viewproxy.NewServer(target, viewproxy.WithPassThrough(target))
 	server.Addr = fmt.Sprintf("localhost:%d", getPort())
 	server.ProxyTimeout = time.Duration(5) * time.Second
 	server.Logger = buildLogger()
 	server.IgnoreHeader("etag")
-	server.PassThrough = true
 
 	server.Get(
 		"/hello/:name",

--- a/pkg/middleware/logging/logging.go
+++ b/pkg/middleware/logging/logging.go
@@ -40,7 +40,7 @@ func Middleware(server *viewproxy.Server, l logger) func(http.Handler) http.Hand
 
 			if route != nil {
 				l.Printf("Handling %s", r.URL.Path)
-			} else if server.PassThrough {
+			} else if server.PassThroughEnabled() {
 				l.Printf("Proxying %s", r.URL.Path)
 			} else {
 				l.Printf("Proxying is disabled and no route matches %s", r.URL.Path)
@@ -53,7 +53,7 @@ func Middleware(server *viewproxy.Server, l logger) func(http.Handler) http.Hand
 
 			if route != nil {
 				l.Printf("Rendered %d in %dms for %s", wrapper.StatusCode, duration.Milliseconds(), r.URL.Path)
-			} else if server.PassThrough {
+			} else if server.PassThroughEnabled() {
 				l.Printf("Proxied %d in %dms for %s", wrapper.StatusCode, duration.Milliseconds(), r.URL.Path)
 			}
 		})

--- a/pkg/middleware/logging/logging_test.go
+++ b/pkg/middleware/logging/logging_test.go
@@ -28,7 +28,8 @@ func (l *SliceLogger) Printf(line string, args ...interface{}) {
 
 func TestLoggingMiddleware(t *testing.T) {
 	targetServer := startTargetServer()
-	viewProxyServer := viewproxy.NewServer(targetServer.URL)
+	viewProxyServer, err := viewproxy.NewServer(targetServer.URL)
+	require.NoError(t, err)
 
 	viewProxyServer.Get(
 		"/hello/:name",
@@ -65,7 +66,8 @@ func TestLoggingMiddleware(t *testing.T) {
 
 func TestLogTripperFragments(t *testing.T) {
 	targetServer := startTargetServer()
-	viewProxyServer := viewproxy.NewServer(targetServer.URL, viewproxy.WithPassThrough(targetServer.URL))
+	viewProxyServer, err := viewproxy.NewServer(targetServer.URL, viewproxy.WithPassThrough(targetServer.URL))
+	require.NoError(t, err)
 
 	viewProxyServer.Get(
 		"/hello/:name",

--- a/pkg/middleware/logging/logging_test.go
+++ b/pkg/middleware/logging/logging_test.go
@@ -61,8 +61,6 @@ func TestLoggingMiddleware(t *testing.T) {
 	require.Equal(t, 404, resp.StatusCode)
 
 	require.Equal(t, "Proxying is disabled and no route matches /fake", log.logs[2])
-
-	viewProxyServer = viewproxy.NewServer(targetServer.URL, viewproxy.WithPassThrough(targetServer.URL))
 }
 
 func TestLogTripperFragments(t *testing.T) {

--- a/pkg/middleware/logging/logging_test.go
+++ b/pkg/middleware/logging/logging_test.go
@@ -29,7 +29,6 @@ func (l *SliceLogger) Printf(line string, args ...interface{}) {
 func TestLoggingMiddleware(t *testing.T) {
 	targetServer := startTargetServer()
 	viewProxyServer := viewproxy.NewServer(targetServer.URL)
-	viewProxyServer.PassThrough = true
 
 	viewProxyServer.Get(
 		"/hello/:name",
@@ -54,31 +53,21 @@ func TestLoggingMiddleware(t *testing.T) {
 	require.Equal(t, "Handling /hello/world", log.logs[0])
 	require.Regexp(t, regexp.MustCompile(`Rendered 200 in \d+ms for /hello/world`), log.logs[1])
 
-	// Proxying request
-	r = httptest.NewRequest("GET", "/fake", nil)
-	w = httptest.NewRecorder()
-	viewProxyServer.CreateHandler().ServeHTTP(w, r)
-	resp = w.Result()
-	require.Equal(t, 404, resp.StatusCode)
-
-	require.Equal(t, "Proxying /fake", log.logs[2])
-	require.Regexp(t, regexp.MustCompile(`Proxied 404 in \d+ms for /fake`), log.logs[3])
-
 	// Proxying disabled
-	viewProxyServer.PassThrough = false
 	r = httptest.NewRequest("GET", "/fake", nil)
 	w = httptest.NewRecorder()
 	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 	resp = w.Result()
 	require.Equal(t, 404, resp.StatusCode)
 
-	require.Equal(t, "Proxying is disabled and no route matches /fake", log.logs[4])
+	require.Equal(t, "Proxying is disabled and no route matches /fake", log.logs[2])
+
+	viewProxyServer = viewproxy.NewServer(targetServer.URL, viewproxy.WithPassThrough(targetServer.URL))
 }
 
 func TestLogTripperFragments(t *testing.T) {
 	targetServer := startTargetServer()
-	viewProxyServer := viewproxy.NewServer(targetServer.URL)
-	viewProxyServer.PassThrough = true
+	viewProxyServer := viewproxy.NewServer(targetServer.URL, viewproxy.WithPassThrough(targetServer.URL))
 
 	viewProxyServer.Get(
 		"/hello/:name",
@@ -95,34 +84,8 @@ func TestLogTripperFragments(t *testing.T) {
 	resp := w.Result()
 	require.Equal(t, 200, resp.StatusCode)
 
-	fmt.Println(log.logs)
-
 	require.Regexp(t, regexp.MustCompile(`Fragment 200 in \d+ms for http:\/\/.*`), log.logs[0])
 	require.Regexp(t, regexp.MustCompile(`Fragment 200 in \d+ms for http:\/\/.*`), log.logs[1])
-}
-
-func TestLogTripperProxy(t *testing.T) {
-	targetServer := startTargetServer()
-	viewProxyServer := viewproxy.NewServer(targetServer.URL)
-	viewProxyServer.PassThrough = true
-
-	viewProxyServer.Get(
-		"/hello/:name",
-		fragment.Define("/layouts/test_layout"),
-		fragment.Collection{fragment.Define("body")},
-	)
-
-	log := &SliceLogger{logs: make([]string, 0)}
-	viewProxyServer.MultiplexerTripper = NewLogTripper(log, secretfilter.New(), multiplexer.NewStandardTripper(&http.Client{}))
-
-	r := httptest.NewRequest("GET", "/fake", nil)
-	w := httptest.NewRecorder()
-	viewProxyServer.CreateHandler().ServeHTTP(w, r)
-	resp := w.Result()
-	require.Equal(t, 404, resp.StatusCode)
-
-	fmt.Println(log.logs)
-	require.Regexp(t, regexp.MustCompile(`Proxy request 404 in \d+ms for http:\/\/.*`), log.logs[0])
 }
 
 func startTargetServer() *httptest.Server {

--- a/server.go
+++ b/server.go
@@ -302,7 +302,6 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request, route *Ro
 
 func (s *Server) handlePassThrough(w http.ResponseWriter, r *http.Request) {
 	if s.passThrough {
-		fmt.Println("serving")
 		s.reverseProxy.ServeHTTP(w, r)
 	} else {
 		w.WriteHeader(404)

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"strings"
 	"time"
@@ -48,9 +49,10 @@ type Server struct {
 	routes        []Route
 	target        string
 	httpServer    *http.Server
+	reverseProxy  *httputil.ReverseProxy
 	Logger        logger
 	ignoreHeaders map[string]bool
-	PassThrough   bool
+	passThrough   bool
 	SecretFilter  secretfilter.Filter
 	// Sets the secret used to generate an HMAC that can be used by the target
 	// server to validate that a request came from viewproxy.
@@ -71,14 +73,16 @@ type Server struct {
 	OnError func(w http.ResponseWriter, r *http.Request, e error)
 }
 
+type ServerOption = func(*Server)
+
 type routeContextKey struct{}
 type parametersContextKey struct{}
 
 const defaultTimeout = 10 * time.Second
 
 // NewServer returns a new Server that will make requests to the given target argument.
-func NewServer(target string) *Server {
-	return &Server{
+func NewServer(target string, opts ...ServerOption) *Server {
+	server := &Server{
 		MultiplexerTripper: multiplexer.NewStandardTripper(&http.Client{}),
 		Logger:             log.Default(),
 		SecretFilter:       secretfilter.New(),
@@ -86,13 +90,36 @@ func NewServer(target string) *Server {
 		ProxyTimeout:       defaultTimeout,
 		ReadTimeout:        defaultTimeout,
 		WriteTimeout:       defaultTimeout,
-		PassThrough:        false,
+		passThrough:        false,
 		AroundRequest:      func(h http.Handler) http.Handler { return h },
 		target:             target,
 		ignoreHeaders:      make(map[string]bool),
 		routes:             make([]Route, 0),
 		tracingConfig:      tracing.TracingConfig{Enabled: false},
 	}
+
+	for _, fn := range opts {
+		fn(server)
+	}
+
+	return server
+}
+
+func WithPassThrough(passthroughTarget string) ServerOption {
+	targetURL, err := url.Parse(passthroughTarget)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return func(server *Server) {
+		server.passThrough = true
+		server.reverseProxy = httputil.NewSingleHostReverseProxy(targetURL)
+	}
+}
+
+func (s *Server) PassThroughEnabled() bool {
+	return s.passThrough
 }
 
 type GetOption = func(*Route)
@@ -165,7 +192,7 @@ func (s *Server) Close() {
 }
 
 // TODO this should probably be a tree structure for faster lookups
-func (s *Server) matchingRoute(path string) (*Route, map[string]string) {
+func (s *Server) MatchingRoute(path string) (*Route, map[string]string) {
 	parts := strings.Split(path, "/")
 
 	for _, route := range s.routes {
@@ -187,7 +214,7 @@ func (s *Server) rootHandler(next http.Handler) http.Handler {
 		ctx, span = tracer.Start(ctx, "ServeHTTP")
 		defer span.End()
 
-		route, parameters := s.matchingRoute(r.URL.Path)
+		route, parameters := s.MatchingRoute(r.URL.Path)
 
 		if r.URL.Path == "/_ping" {
 			w.WriteHeader(http.StatusOK)
@@ -212,7 +239,7 @@ func (s *Server) requestHandler() http.Handler {
 			parameters := ParametersFromContext(ctx)
 			s.handleRequest(w, r, route, parameters, ctx)
 		} else {
-			s.passThrough(w, r)
+			s.handlePassThrough(w, r)
 		}
 	})
 }
@@ -273,41 +300,10 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request, route *Ro
 	resBuilder.Write()
 }
 
-func (s *Server) passThrough(w http.ResponseWriter, r *http.Request) {
-	if s.PassThrough {
-		targetUrl, err := url.Parse(
-			fmt.Sprintf("%s/%s", strings.TrimRight(s.target, "/"), strings.TrimLeft(r.URL.String(), "/")),
-		)
-
-		targetUrl.RawQuery = r.URL.Query().Encode()
-
-		if err != nil {
-			s.handleProxyError(err, w)
-			return
-		}
-
-		req := s.newRequest()
-		req.Non2xxErrors = false
-
-		req.WithHeadersFromRequest(r)
-		result, err := req.DoSingle(
-			r.Context(),
-			r.Method,
-			targetUrl.String(),
-			r.Body,
-		)
-
-		if err != nil {
-			s.handleProxyError(err, w)
-			return
-		}
-
-		resBuilder := newResponseBuilder(*s, w)
-		resBuilder.StatusCode = result.StatusCode
-		results := []*multiplexer.Result{result}
-		resBuilder.SetHeaders(result.HeadersWithoutProxyHeaders(), results)
-		resBuilder.SetFragments(results)
-		resBuilder.Write()
+func (s *Server) handlePassThrough(w http.ResponseWriter, r *http.Request) {
+	if s.passThrough {
+		fmt.Println("serving")
+		s.reverseProxy.ServeHTTP(w, r)
 	} else {
 		w.WriteHeader(404)
 		w.Write([]byte("404 not found"))

--- a/server_test.go
+++ b/server_test.go
@@ -34,7 +34,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestServer(t *testing.T) {
-	viewProxyServer := NewServer(targetServer.URL)
+	viewProxyServer, err := NewServer(targetServer.URL)
+	require.NoError(t, err)
 	viewProxyServer.Addr = "localhost:9998"
 	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
 
@@ -109,7 +110,8 @@ func TestServer(t *testing.T) {
 }
 
 func TestHealthCheck(t *testing.T) {
-	viewProxyServer := NewServer(targetServer.URL)
+	viewProxyServer, err := NewServer(targetServer.URL)
+	require.NoError(t, err)
 	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
 
 	r := httptest.NewRequest("GET", "/_ping", nil)
@@ -127,7 +129,8 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func TestQueryParamForwardingServer(t *testing.T) {
-	viewProxyServer := NewServer(targetServer.URL)
+	viewProxyServer, err := NewServer(targetServer.URL)
+	require.NoError(t, err)
 	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
 
 	viewProxyServer.IgnoreHeader("etag")
@@ -156,7 +159,8 @@ func TestQueryParamForwardingServer(t *testing.T) {
 }
 
 func TestPassThroughEnabled(t *testing.T) {
-	viewProxyServer := NewServer(targetServer.URL, WithPassThrough(targetServer.URL))
+	viewProxyServer, err := NewServer(targetServer.URL, WithPassThrough(targetServer.URL))
+	require.NoError(t, err)
 	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
 
 	r := httptest.NewRequest("GET", "/oops", nil)
@@ -173,7 +177,8 @@ func TestPassThroughEnabled(t *testing.T) {
 }
 
 func TestPassThroughDisabled(t *testing.T) {
-	viewProxyServer := NewServer(targetServer.URL)
+	viewProxyServer, err := NewServer(targetServer.URL)
+	require.NoError(t, err)
 
 	r := httptest.NewRequest("GET", "/hello/world", nil)
 	w := httptest.NewRecorder()
@@ -203,7 +208,8 @@ func TestPassThroughPostRequest(t *testing.T) {
 		require.Equal(t, "hello", string(body))
 	}))
 
-	viewProxyServer := NewServer(server.URL, WithPassThrough(server.URL))
+	viewProxyServer, err := NewServer(server.URL, WithPassThrough(server.URL))
+	require.NoError(t, err)
 
 	r := httptest.NewRequest("POST", "/hello/world", strings.NewReader("hello"))
 	w := httptest.NewRecorder()
@@ -245,7 +251,8 @@ func TestFragmentSendsVerifiableHmacWhenSet(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	viewProxyServer := NewServer(server.URL)
+	viewProxyServer, err := NewServer(server.URL)
+	require.NoError(t, err)
 	viewProxyServer.Get("/hello/:name", fragment.Define("/foo"), fragment.Collection{})
 	viewProxyServer.HmacSecret = secret
 
@@ -278,7 +285,8 @@ func TestFragmentSetsCorrectHeaders(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	viewProxyServer := NewServer(server.URL)
+	viewProxyServer, err := NewServer(server.URL)
+	require.NoError(t, err)
 	layout := fragment.Define("/foo", fragment.WithTimingLabel("foo"))
 	content := fragment.Define("/bar", fragment.WithTimingLabel("bar"))
 	viewProxyServer.Get("/hello/:name", layout, fragment.Collection{content})
@@ -325,7 +333,8 @@ func TestSupportsGzip(t *testing.T) {
 		w.Write(b.Bytes())
 	}))
 
-	viewProxyServer := NewServer(server.URL)
+	viewProxyServer, err := NewServer(server.URL)
+	require.NoError(t, err)
 	viewProxyServer.Get("/hello/:name", fragment.Define("/layout"), fragment.Collection{fragment.Define("/fragment")})
 
 	r := httptest.NewRequest("GET", "/hello/world", nil)
@@ -350,7 +359,8 @@ func TestSupportsGzip(t *testing.T) {
 func TestAroundRequestCallback(t *testing.T) {
 	done := make(chan struct{})
 
-	server := NewServer("http://fake.net")
+	server, err := NewServer("http://fake.net")
+	require.NoError(t, err)
 	server.Get("/hello/:name", fragment.Define("/layout"), fragment.Collection{fragment.Define("/fragment")})
 	server.AroundRequest = func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -380,7 +390,8 @@ func TestOnErrorHandler(t *testing.T) {
 	defer cancel()
 	done := make(chan struct{})
 
-	server := NewServer(targetServer.URL)
+	server, err := NewServer(targetServer.URL)
+	require.NoError(t, err)
 	server.Get("/hello/:name", fragment.Define("/definitely_missing_and_not_defined"), fragment.Collection{})
 	server.AroundRequest = func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -429,7 +440,8 @@ func (t *contextTestTripper) Request(r *http.Request) (*http.Response, error) {
 }
 
 func TestRoundTripperContext(t *testing.T) {
-	viewProxyServer := NewServer(targetServer.URL)
+	viewProxyServer, err := NewServer(targetServer.URL)
+	require.NoError(t, err)
 	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
 	tripper := &contextTestTripper{}
 	viewProxyServer.MultiplexerTripper = tripper
@@ -453,6 +465,14 @@ func TestRoundTripperContext(t *testing.T) {
 	require.Equal(t, 200, resp.StatusCode)
 	require.Equal(t, 4, len(tripper.requestables))
 	require.NotNil(t, tripper.route)
+}
+
+func TestWithPassThrough_Error(t *testing.T) {
+	_, err := NewServer(targetServer.URL, WithPassThrough("%invalid%"))
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "viewproxy.ServerOption error")
+	require.Contains(t, err.Error(), "WithPassThrough error")
 }
 
 func startTargetServer() *httptest.Server {


### PR DESCRIPTION
This migrates the existing pass through proxy mode to utilize the
built-in `httputil.ReverseProxy` module.

This causes some of our logging to no longer work but gives us a more
reliable, community tested reverse proxy.
