### PR TITLE
Use a buffered error channel and defer closing it

### DIFF
--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -90,10 +90,7 @@ func (r *Request) Do(ctx context.Context) ([]*Result, error) {
 
 	wg := sync.WaitGroup{}
 	reqCount := len(r.requestables)
-
 	errCh := make(chan error, reqCount)
-	defer close(errCh)
-
 	results := make([]*Result, reqCount)
 
 	for i, f := range r.requestables {

--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -89,9 +89,12 @@ func (r *Request) Do(ctx context.Context) ([]*Result, error) {
 	defer cancel()
 
 	wg := sync.WaitGroup{}
-	errCh := make(chan error)
+	reqCount := len(r.requestables)
 
-	results := make([]*Result, len(r.requestables))
+	errCh := make(chan error, reqCount)
+	defer close(errCh)
+
+	results := make([]*Result, reqCount)
 
 	for i, f := range r.requestables {
 		wg.Add(1)


### PR DESCRIPTION
This prevents goroutines stacking up when all fragment requests generate an error and pushing to the error channel would block and also hold up the wait group.