### PR TITLE
Add middleware for generating response after fragments are fetched

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ import "github.com/blakewilliams/viewproxy/pkg/fragment"
 server := viewproxy.NewServer(target)
 server.Port = 3005
 server.ProxyTimeout = time.Duration(5) * time.Second
-server.IgnoreHeader("etag")
 server.PassThrough = true
 
 // Define a route with a :name parameter that will be forwarded to the target host.

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -26,7 +26,6 @@ func main() {
 	server.Addr = fmt.Sprintf("localhost:%d", getPort())
 	server.ProxyTimeout = time.Duration(5) * time.Second
 	server.Logger = buildLogger()
-	server.IgnoreHeader("etag")
 
 	server.Get(
 		"/hello/:name",
@@ -37,6 +36,13 @@ func main() {
 			fragment.Define("footer"),
 		},
 	)
+
+	server.AroundResponseHeaders = func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			// Strip etag header from response
+			rw.Header().Del("etag")
+		})
+	}
 
 	// setup middleware
 	server.AroundRequest = func(handler http.Handler) http.Handler {

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -37,7 +37,7 @@ func main() {
 		},
 	)
 
-	server.AroundResponseHeaders = func(h http.Handler) http.Handler {
+	server.AroundResponse = func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			// Strip etag header from response
 			rw.Header().Del("etag")

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -41,6 +41,7 @@ func main() {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			// Strip etag header from response
 			rw.Header().Del("etag")
+			h.ServeHTTP(rw, r)
 		})
 	}
 

--- a/pkg/multiplexer/headers.go
+++ b/pkg/multiplexer/headers.go
@@ -74,6 +74,8 @@ func WithDefaultHeaders(next http.Handler) http.Handler {
 					rw.Header().Add(name, value)
 				}
 			}
+
+			rw.Header().Del("Content-Length")
 		}
 
 		next.ServeHTTP(rw, r)

--- a/pkg/multiplexer/headers.go
+++ b/pkg/multiplexer/headers.go
@@ -1,6 +1,7 @@
 package multiplexer
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -62,3 +63,20 @@ func forwardedForFromRequest(req *http.Request) string {
 
 	return host
 }
+
+type headerResponseWriter struct {
+	headers http.Header
+}
+
+func (hrw *headerResponseWriter) Header() http.Header {
+	return hrw.headers
+}
+
+func (hrw *headerResponseWriter) Write(b []byte) (int, error) {
+	return 0, errors.New("Write not supported on response")
+}
+
+func (rw *headerResponseWriter) WriteHeader(status int) {
+}
+
+var _ http.ResponseWriter = &headerResponseWriter{}

--- a/pkg/multiplexer/headers.go
+++ b/pkg/multiplexer/headers.go
@@ -85,7 +85,7 @@ func SetHeaders(results []*Result, rw http.ResponseWriter, r *http.Request, hand
 	wrapped := &headerResponseWriter{headers: results[0].HeadersWithoutProxyHeaders()}
 	r = r.WithContext(ContextWithResults(r.Context(), results))
 
-	handler.ServeHTTP(rw, r)
+	handler.ServeHTTP(wrapped, r)
 
 	wrapped.headers.Del("Content-Length")
 

--- a/pkg/multiplexer/headers.go
+++ b/pkg/multiplexer/headers.go
@@ -80,3 +80,18 @@ func (rw *headerResponseWriter) WriteHeader(status int) {
 }
 
 var _ http.ResponseWriter = &headerResponseWriter{}
+
+func SetHeaders(results []*Result, rw http.ResponseWriter, r *http.Request, handler http.Handler) {
+	wrapped := &headerResponseWriter{headers: results[0].HeadersWithoutProxyHeaders()}
+	r = r.WithContext(ContextWithResults(r.Context(), results))
+
+	handler.ServeHTTP(rw, r)
+
+	wrapped.headers.Del("Content-Length")
+
+	for name, values := range wrapped.headers {
+		for _, value := range values {
+			rw.Header().Add(name, value)
+		}
+	}
+}

--- a/pkg/multiplexer/result.go
+++ b/pkg/multiplexer/result.go
@@ -1,6 +1,7 @@
 package multiplexer
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -47,4 +48,21 @@ func (r *Result) HeadersWithoutProxyHeaders() http.Header {
 	}
 
 	return headers
+}
+
+type resultsContextKey struct{}
+
+func ResultsFromContext(ctx context.Context) []*Result {
+	if ctx == nil {
+		return nil
+	}
+
+	if results := ctx.Value(resultsContextKey{}); results != nil {
+		return results.([]*Result)
+	}
+	return nil
+}
+
+func ContextWithResults(ctx context.Context, results []*Result) context.Context {
+	return context.WithValue(ctx, resultsContextKey{}, results)
 }

--- a/pkg/multiplexer/result.go
+++ b/pkg/multiplexer/result.go
@@ -15,7 +15,6 @@ type ResultError struct {
 type Results interface {
 	Error() error
 	Results() []*Result
-	StartTime() time.Time
 }
 
 func newResultError(req *Request, res *Result) *ResultError {
@@ -87,7 +86,6 @@ func ResultsFromContext(ctx context.Context) Results {
 	return nil
 }
 
-func ContextWithResults(ctx context.Context, results []*Result, err error, startTime time.Time) context.Context {
-	wrapper := &resultsWrapper{results: results, err: err, startTime: startTime}
-	return context.WithValue(ctx, resultsContextKey{}, wrapper)
+func ContextWithResults(ctx context.Context, results []*Result, err error) context.Context {
+	return context.WithValue(ctx, resultsContextKey{}, &resultsWrapper{results: results, err: err})
 }

--- a/pkg/multiplexer/server_timing.go
+++ b/pkg/multiplexer/server_timing.go
@@ -9,7 +9,8 @@ import (
 
 const resultTimingLabel = "fragment"
 
-func WithCombinedServerTimingHeader(r *http.Request, headers http.Header, results []*Result) http.Header {
+func WithCombinedServerTimingHeader(rw http.ResponseWriter, r *http.Request) {
+	results := ResultsFromContext(r.Context())
 	metrics := []*servertiming.Metric{}
 
 	for _, result := range results {
@@ -47,8 +48,6 @@ func WithCombinedServerTimingHeader(r *http.Request, headers http.Header, result
 			segments = append(segments, metric.String())
 		}
 
-		headers.Set(servertiming.HeaderKey, strings.Join(segments, ","))
+		rw.Header().Set(servertiming.HeaderKey, strings.Join(segments, ","))
 	}
-
-	return headers
 }

--- a/pkg/multiplexer/server_timing.go
+++ b/pkg/multiplexer/server_timing.go
@@ -9,7 +9,7 @@ import (
 
 const resultTimingLabel = "fragment"
 
-func SetCombinedServerTimingHeader(results []*Result, writer http.ResponseWriter) {
+func WithCombinedServerTimingHeader(r *http.Request, headers http.Header, results []*Result) http.Header {
 	metrics := []*servertiming.Metric{}
 
 	for _, result := range results {
@@ -41,14 +41,14 @@ func SetCombinedServerTimingHeader(results []*Result, writer http.ResponseWriter
 		}
 	}
 
-	if len(metrics) == 0 {
-		return
+	if len(metrics) > 0 {
+		segments := make([]string, 0, len(metrics))
+		for _, metric := range metrics {
+			segments = append(segments, metric.String())
+		}
+
+		headers.Set(servertiming.HeaderKey, strings.Join(segments, ","))
 	}
 
-	segments := make([]string, 0, len(metrics))
-	for _, metric := range metrics {
-		segments = append(segments, metric.String())
-	}
-
-	writer.Header().Set(servertiming.HeaderKey, strings.Join(segments, ","))
+	return headers
 }

--- a/pkg/multiplexer/server_timing.go
+++ b/pkg/multiplexer/server_timing.go
@@ -9,8 +9,26 @@ import (
 
 const resultTimingLabel = "fragment"
 
-func WithCombinedServerTimingHeader(rw http.ResponseWriter, r *http.Request) {
-	results := ResultsFromContext(r.Context())
+func WithCombinedServerTimingHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if results := ResultsFromContext(r.Context()); results != nil {
+			metrics := metricsForResults(results.Results())
+
+			if len(metrics) > 0 {
+				segments := make([]string, 0, len(metrics))
+				for _, metric := range metrics {
+					segments = append(segments, metric.String())
+				}
+
+				rw.Header().Set(servertiming.HeaderKey, strings.Join(segments, ","))
+			}
+		}
+
+		next.ServeHTTP(rw, r)
+	})
+}
+
+func metricsForResults(results []*Result) []*servertiming.Metric {
 	metrics := []*servertiming.Metric{}
 
 	for _, result := range results {
@@ -42,12 +60,5 @@ func WithCombinedServerTimingHeader(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if len(metrics) > 0 {
-		segments := make([]string, 0, len(metrics))
-		for _, metric := range metrics {
-			segments = append(segments, metric.String())
-		}
-
-		rw.Header().Set(servertiming.HeaderKey, strings.Join(segments, ","))
-	}
+	return metrics
 }

--- a/pkg/routeimporter/http_test.go
+++ b/pkg/routeimporter/http_test.go
@@ -68,7 +68,6 @@ func TestLoadHttp_ContextTimeout(t *testing.T) {
 	<-ctx.Done()
 	duration := time.Now().Sub(start)
 
-	fmt.Println(duration)
 	require.LessOrEqual(t, duration, time.Millisecond*40)
 }
 

--- a/response_builder.go
+++ b/response_builder.go
@@ -87,7 +87,6 @@ func withCombinedFragments(s *Server) http.Handler {
 		results := multiplexer.ResultsFromContext(r.Context())
 
 		if results != nil && results.Error() == nil {
-			rw.Header().Del("Content-Length")
 			resBuilder := newResponseBuilder(*s, rw)
 			resBuilder.SetLayout(results.Results()[0])
 			resBuilder.SetFragments(results.Results()[1:])

--- a/response_builder.go
+++ b/response_builder.go
@@ -3,6 +3,7 @@ package viewproxy
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -24,8 +25,15 @@ func (rb *responseBuilder) SetLayout(result *multiplexer.Result) {
 	rb.body = result.Body
 }
 
-func (rb *responseBuilder) SetHeaders(headers http.Header) {
-	for name, values := range headers {
+func (rb *responseBuilder) SetHeaders(results []*multiplexer.Result, r *http.Request, handler http.Handler) {
+	rw := &headerResponseWriter{headers: results[0].HeadersWithoutProxyHeaders()}
+	r = r.WithContext(multiplexer.ContextWithResults(r.Context(), results))
+
+	handler.ServeHTTP(rw, r)
+
+	rw.headers.Del("Content-Length")
+
+	for name, values := range rw.headers {
 		for _, value := range values {
 			rb.writer.Header().Add(name, value)
 		}
@@ -75,3 +83,20 @@ func (rb *responseBuilder) Write() {
 		rb.writer.Write(rb.body)
 	}
 }
+
+type headerResponseWriter struct {
+	headers http.Header
+}
+
+func (hrw *headerResponseWriter) Header() http.Header {
+	return hrw.headers
+}
+
+func (hrw *headerResponseWriter) Write(b []byte) (int, error) {
+	return 0, errors.New("Write not supported on response")
+}
+
+func (rw *headerResponseWriter) WriteHeader(status int) {
+}
+
+var _ http.ResponseWriter = &headerResponseWriter{}

--- a/response_builder.go
+++ b/response_builder.go
@@ -90,7 +90,7 @@ func withCombinedFragments(s *Server) http.Handler {
 			resBuilder := newResponseBuilder(*s, rw)
 			resBuilder.SetLayout(results.Results()[0])
 			resBuilder.SetFragments(results.Results()[1:])
-			elapsed := time.Since(results.StartTime())
+			elapsed := time.Since(startTimeFromContext(r.Context()))
 			resBuilder.SetDuration(elapsed.Milliseconds())
 			resBuilder.Write()
 		}

--- a/response_builder.go
+++ b/response_builder.go
@@ -24,17 +24,11 @@ func (rb *responseBuilder) SetLayout(result *multiplexer.Result) {
 	rb.body = result.Body
 }
 
-func (rb *responseBuilder) SetHeaders(headers http.Header, results []*multiplexer.Result) {
+func (rb *responseBuilder) SetHeaders(headers http.Header) {
 	for name, values := range headers {
-		if !rb.server.ignoreHeaders[http.CanonicalHeaderKey(name)] {
-			for _, value := range values {
-				rb.writer.Header().Add(name, value)
-			}
+		for _, value := range values {
+			rb.writer.Header().Add(name, value)
 		}
-	}
-
-	if len(results) > 1 {
-		multiplexer.SetCombinedServerTimingHeader(results, rb.writer)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -2,7 +2,6 @@ package viewproxy
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -66,15 +65,13 @@ type Server struct {
 	// requests.
 	// HttpTransport      http.RoundTripper
 	MultiplexerTripper multiplexer.Tripper
-	// A function to wrap request handling with other middleware
+	// A function to wrap the entire request handling with other middleware
 	AroundRequest func(http.Handler) http.Handler
-	// A function to wrap around the generating of the response headers after
-	// the results have been fetched but before the response body has been set
-	AroundResponseHeaders func(http.Handler) http.Handler
-	tracingConfig         tracing.TracingConfig
-	// A function that is called when an error occurs in the viewproxy handler
-	OnError       func(w http.ResponseWriter, r *http.Request, e error)
-	headerHandler http.Handler
+	// A function to wrap around the generating of the response after the fragment
+	// requests have completed or errored
+	AroundResponse  func(http.Handler) http.Handler
+	tracingConfig   tracing.TracingConfig
+	responseHandler http.Handler
 }
 
 type ServerOption = func(*Server) error
@@ -84,23 +81,26 @@ type parametersContextKey struct{}
 
 const defaultTimeout = 10 * time.Second
 
+func emptyMiddleware(h http.Handler) http.Handler          { return h }
+func emptyHandler(rw http.ResponseWriter, r *http.Request) {}
+
 // NewServer returns a new Server that will make requests to the given target argument.
 func NewServer(target string, opts ...ServerOption) (*Server, error) {
 	server := &Server{
-		MultiplexerTripper:    multiplexer.NewStandardTripper(&http.Client{}),
-		Logger:                log.Default(),
-		SecretFilter:          secretfilter.New(),
-		Addr:                  "localhost:3005",
-		ProxyTimeout:          defaultTimeout,
-		ReadTimeout:           defaultTimeout,
-		WriteTimeout:          defaultTimeout,
-		passThrough:           false,
-		AroundRequest:         func(h http.Handler) http.Handler { return h },
-		AroundResponseHeaders: func(h http.Handler) http.Handler { return h },
-		target:                target,
-		routes:                make([]Route, 0),
-		tracingConfig:         tracing.TracingConfig{Enabled: false},
-		headerHandler:         http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {}),
+		MultiplexerTripper: multiplexer.NewStandardTripper(&http.Client{}),
+		Logger:             log.Default(),
+		SecretFilter:       secretfilter.New(),
+		Addr:               "localhost:3005",
+		ProxyTimeout:       defaultTimeout,
+		ReadTimeout:        defaultTimeout,
+		WriteTimeout:       defaultTimeout,
+		passThrough:        false,
+		AroundRequest:      emptyMiddleware,
+		AroundResponse:     emptyMiddleware,
+		target:             target,
+		routes:             make([]Route, 0),
+		tracingConfig:      tracing.TracingConfig{Enabled: false},
+		responseHandler:    http.HandlerFunc(emptyHandler),
 	}
 
 	for _, fn := range opts {
@@ -239,8 +239,14 @@ func (s *Server) CreateHandler() http.Handler {
 	return s.rootHandler(s.AroundRequest(s.requestHandler()))
 }
 
-func (s *Server) createHeaderHandler() http.Handler {
-	return s.AroundResponseHeaders(http.HandlerFunc(multiplexer.WithCombinedServerTimingHeader))
+func (s *Server) createResponseHandler() http.Handler {
+	handler := withCombinedFragments(s)
+	handler = withDefaultErrorHandler(handler)
+	handler = s.AroundResponse(handler)
+	handler = multiplexer.WithCombinedServerTimingHeader(handler)
+	handler = multiplexer.WithDefaultHeaders(handler)
+
+	return handler
 }
 
 func (s *Server) newRequest() *multiplexer.Request {
@@ -275,28 +281,8 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request, route *Ro
 	req.Header.Set(HeaderViewProxyOriginalPath, r.URL.RequestURI())
 	results, err := req.Do(ctx)
 
-	if err != nil {
-		if s.OnError != nil {
-			var resultErr *ResultError
-			if errors.As(err, &resultErr) {
-				multiplexer.SetHeaders([]*multiplexer.Result{resultErr.Result}, w, r, s.headerHandler)
-			}
-			s.OnError(w, r, err)
-			return
-		} else {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("500 internal server error"))
-			return
-		}
-	}
-
-	resBuilder := newResponseBuilder(*s, w)
-	resBuilder.SetLayout(results[0])
-	multiplexer.SetHeaders(results, w, r, s.headerHandler)
-	resBuilder.SetFragments(results[1:])
-	elapsed := time.Since(startTime)
-	resBuilder.SetDuration(elapsed.Milliseconds())
-	resBuilder.Write()
+	r = r.WithContext(multiplexer.ContextWithResults(r.Context(), results, err, startTime))
+	s.responseHandler.ServeHTTP(w, r)
 }
 
 func (s *Server) handlePassThrough(w http.ResponseWriter, r *http.Request) {
@@ -379,7 +365,7 @@ func (s *Server) configureServer(serveFn func() error) error {
 		MaxHeaderBytes: 1 << 20,
 	}
 
-	s.headerHandler = s.createHeaderHandler()
+	s.responseHandler = s.createResponseHandler()
 
 	return serveFn()
 }

--- a/server.go
+++ b/server.go
@@ -235,7 +235,7 @@ func (s *Server) requestHandler() http.Handler {
 	})
 }
 
-func (s *Server) createHandler() http.Handler {
+func (s *Server) CreateHandler() http.Handler {
 	return s.rootHandler(s.AroundRequest(s.requestHandler()))
 }
 
@@ -373,7 +373,7 @@ func (s *Server) configureServer(serveFn func() error) error {
 
 	s.httpServer = &http.Server{
 		Addr:           s.Addr,
-		Handler:        s.createHandler(),
+		Handler:        s.CreateHandler(),
 		ReadTimeout:    s.ReadTimeout,
 		WriteTimeout:   s.WriteTimeout,
 		MaxHeaderBytes: 1 << 20,

--- a/server.go
+++ b/server.go
@@ -282,7 +282,7 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request, route *Ro
 	results, err := req.Do(ctx)
 
 	handlerCtx := context.WithValue(r.Context(), startTimeKey{}, startTime)
-	handlerCtx = multiplexer.ContextWithResults(ctx, results, err)
+	handlerCtx = multiplexer.ContextWithResults(handlerCtx, results, err)
 	handler.ServeHTTP(w, r.WithContext(handlerCtx))
 }
 

--- a/server.go
+++ b/server.go
@@ -287,7 +287,6 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request, route *Ro
 
 	resBuilder := newResponseBuilder(*s, w)
 	resBuilder.SetLayout(results[0])
-	fmt.Println(s.headerHandler)
 	resBuilder.SetHeaders(results, r, s.headerHandler)
 	resBuilder.SetFragments(results[1:])
 	elapsed := time.Since(startTime)

--- a/server.go
+++ b/server.go
@@ -295,11 +295,6 @@ func (s *Server) handlePassThrough(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) handleProxyError(err error, w http.ResponseWriter) {
-	w.WriteHeader(http.StatusInternalServerError)
-	w.Write([]byte("Internal Server Error"))
-}
-
 func RouteFromContext(ctx context.Context) *Route {
 	if ctx == nil {
 		return nil

--- a/server_test.go
+++ b/server_test.go
@@ -44,7 +44,6 @@ func TestServer(t *testing.T) {
 			next.ServeHTTP(rw, r)
 		})
 	}
-	viewProxyServer.responseHandler = viewProxyServer.createResponseHandler()
 
 	layout := fragment.Define("/layouts/test_layout")
 	fragments := fragment.Collection{
@@ -369,7 +368,6 @@ func TestErrorHandler(t *testing.T) {
 			require.Equal(t, 404, resultErr.Result.StatusCode)
 		})
 	}
-	server.responseHandler = server.createResponseHandler()
 
 	fakeWriter := httptest.NewRecorder()
 	fakeRequest := httptest.NewRequest("GET", "/hello/world", nil)
@@ -472,8 +470,6 @@ func startTargetServer() *httptest.Server {
 func newServer(t *testing.T, target string, opts ...ServerOption) *Server {
 	server, err := NewServer(target, opts...)
 	require.NoError(t, err)
-
-	server.responseHandler = server.createResponseHandler()
 
 	return server
 }

--- a/server_test.go
+++ b/server_test.go
@@ -80,7 +80,7 @@ func TestHealthCheck(t *testing.T) {
 	r := httptest.NewRequest("GET", "/_ping", nil)
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 
@@ -107,7 +107,7 @@ func TestQueryParamForwardingServer(t *testing.T) {
 	r := httptest.NewRequest("GET", "/hello/world?important=true&name=override", nil)
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 
@@ -127,7 +127,7 @@ func TestPassThroughEnabled(t *testing.T) {
 	r := httptest.NewRequest("GET", "/oops", nil)
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 	body, err := ioutil.ReadAll(resp.Body)
@@ -144,7 +144,7 @@ func TestPassThroughDisabled(t *testing.T) {
 	r := httptest.NewRequest("GET", "/hello/world", nil)
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 	body, err := ioutil.ReadAll(resp.Body)
@@ -175,7 +175,7 @@ func TestPassThroughPostRequest(t *testing.T) {
 	r := httptest.NewRequest("POST", "/hello/world", strings.NewReader("hello"))
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	select {
 	case <-done:
@@ -220,7 +220,7 @@ func TestFragmentSendsVerifiableHmacWhenSet(t *testing.T) {
 	r := httptest.NewRequest("GET", "/hello/world", strings.NewReader("hello"))
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	<-done
 
@@ -259,7 +259,7 @@ func TestFragmentSetsCorrectHeaders(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	viewProxyServer.headerHandler = viewProxyServer.createHeaderHandler()
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	<-layoutDone
 	<-fragmentDone
@@ -303,7 +303,7 @@ func TestSupportsGzip(t *testing.T) {
 	r.Header.Set("Accept-Encoding", "gzip")
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 
@@ -338,7 +338,7 @@ func TestAroundRequestCallback(t *testing.T) {
 	r := httptest.NewRequest("GET", "/hello/world", nil)
 	r.RemoteAddr = "192.168.1.1"
 
-	server.createHandler().ServeHTTP(w, r)
+	server.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 
@@ -386,7 +386,7 @@ func TestOnErrorHandler(t *testing.T) {
 	fakeRequest := httptest.NewRequest("GET", "/hello/world", nil)
 	fakeRequest.RemoteAddr = "192.168.1.1"
 
-	server.createHandler().ServeHTTP(fakeWriter, fakeRequest)
+	server.CreateHandler().ServeHTTP(fakeWriter, fakeRequest)
 
 	require.Equal(t, "true", fakeWriter.Header().Get("x-viewproxy"))
 	require.Equal(t, "true", fakeWriter.Header().Get("error-header"))
@@ -427,7 +427,7 @@ func TestRoundTripperContext(t *testing.T) {
 	r := httptest.NewRequest("GET", "/hello/world?important=true&name=override", nil)
 	w := httptest.NewRecorder()
 
-	viewProxyServer.createHandler().ServeHTTP(w, r)
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
 
 	resp := w.Result()
 

--- a/server_test.go
+++ b/server_test.go
@@ -362,6 +362,13 @@ func TestOnErrorHandler(t *testing.T) {
 			next.ServeHTTP(w, r)
 		})
 	}
+	server.AroundResponseHeaders = func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Header().Set("error-header", "true")
+		})
+	}
+	server.headerHandler = server.createHeaderHandler()
+
 	server.OnError = func(w http.ResponseWriter, r *http.Request, e error) {
 		defer close(done)
 		var resultErr *ResultError
@@ -382,6 +389,7 @@ func TestOnErrorHandler(t *testing.T) {
 	server.createHandler().ServeHTTP(fakeWriter, fakeRequest)
 
 	require.Equal(t, "true", fakeWriter.Header().Get("x-viewproxy"))
+	require.Equal(t, "true", fakeWriter.Header().Get("error-header"))
 
 	select {
 	case <-done:


### PR DESCRIPTION
This pull request adds a new `AroundResponse` middleware that runs after the fragment results have completed but before the response is written.

This will give consumers the ability to configure all the headers and response body before they are sent on the response while accessing the headers on the individual fragment responses.

This removes the `IgnoreHeader` and `OnError` APIs since this new API gives a broader option for stripping, updating, adding headers, and serving error pages.

I chose to just re-use the existing `http.Handler` pattern instead of adding something new for consistency with the full request middleware we already have (`AroundRequest`).

The server timing middleware was updated to use this new API which felt cleaner. This felt like something likely to be useful via this API where we want to combine a header from the fragment responses in a specific way in the main response header.

Feedback appreciated.