### PR TITLE
Remove ping endpoint

### DIFF
--- a/server.go
+++ b/server.go
@@ -205,12 +205,6 @@ func (s *Server) rootHandler(next http.Handler) http.Handler {
 
 		route, parameters := s.MatchingRoute(r.URL.Path)
 
-		if r.URL.Path == "/_ping" {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("200 ok"))
-			return
-		}
-
 		if route != nil {
 			ctx = context.WithValue(ctx, routeContextKey{}, route)
 			ctx = context.WithValue(ctx, parametersContextKey{}, parameters)

--- a/server_test.go
+++ b/server_test.go
@@ -70,24 +70,6 @@ func TestServer(t *testing.T) {
 	require.Equal(t, "", resp.Header.Get("etag"), "Expected response to have removed etag header")
 }
 
-func TestHealthCheck(t *testing.T) {
-	viewProxyServer := newServer(t, targetServer.URL)
-	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
-
-	r := httptest.NewRequest("GET", "/_ping", nil)
-	w := httptest.NewRecorder()
-
-	viewProxyServer.CreateHandler().ServeHTTP(w, r)
-
-	resp := w.Result()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	require.Nil(t, err)
-	expected := "200 ok"
-
-	require.Equal(t, expected, string(body))
-}
-
 func TestQueryParamForwardingServer(t *testing.T) {
 	viewProxyServer := newServer(t, targetServer.URL)
 	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)


### PR DESCRIPTION
I believe this existed before consumers could use `AroundRequest` to implement it so it seems worth removing now and ensure consumers do it instead.