### PR TITLE
Fix uri encoding issue for named fragments

### DIFF
--- a/pkg/fragment/definition.go
+++ b/pkg/fragment/definition.go
@@ -93,7 +93,13 @@ func (d *Definition) Requestable(target *url.URL, pathParams map[string]string, 
 		}
 	}
 
-	request.Path = path.String()
+	unescapedPath, err := url.PathUnescape(path.String())
+	if err != nil {
+		return nil, fmt.Errorf("could not encode url: %w", err)
+	}
+	request.Path = unescapedPath    // Set unescaped path which treats %2f as a /
+	request.RawPath = path.String() // Set RawPath which lets go correlate %2f to / in the Path, and escape correctly when calling String()
+
 	request.RawQuery = query.Encode()
 
 	return &Request{

--- a/pkg/fragment/definition_test.go
+++ b/pkg/fragment/definition_test.go
@@ -31,3 +31,14 @@ func TestFragment_IntoRequestable_MissingDynamicPart(t *testing.T) {
 	require.Error(t, err)
 	require.EqualError(t, err, "no parameter was provided for :name in route /hello/:name")
 }
+
+func TestFragment_IntoRequestable_HandlesURLEncodings(t *testing.T) {
+	definition := Define("/hello/:name")
+	requestable, err := definition.Requestable(
+		target,
+		map[string]string{":name": "mulder%2fscully"},
+		url.Values{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "http://fake.net/hello/mulder%2fscully", requestable.URL())
+}


### PR DESCRIPTION
As-is, when Voltron processes a url containing `%2f` it is read as an
actual `/` by the router due to the use of `request.URL.Path` instead of
`request.URL.EscapedPath()` which includes the escapes correctly.

This fixes the route matching issue by using `EscapedPath` instead of
`Path`.

Additionally, the parameters being passed to the target server were
being double escaped since the `request.Path` was being set to include
the `%2f` escape. To resolve this, `request.Path` is set to the
*unescaped* path, and `request.RawPath` is set to the escaped path. This
generates the expected URL with the `%2f` escape instead of `%252`.

Due to `url.PathUnescape` possibly returning an error, this introduces
another potential way to fail to serve a request and will result in a
panic if it does return an error.
