### PR TITLE
Filter named route params from URLs

### DIFF
--- a/pkg/fragment/definition.go
+++ b/pkg/fragment/definition.go
@@ -101,7 +101,7 @@ func (d *Definition) Requestable(target *url.URL, pathParams map[string]string, 
 		}
 	}
 
-	request, err := buildURL(target, path.String(), query.Encode())
+	requestURL, err := buildURL(target, path.String(), query.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (d *Definition) Requestable(target *url.URL, pathParams map[string]string, 
 	}
 
 	return &Request{
-		RequestURL:  request,
+		RequestURL:  requestURL,
 		Definition:  d,
 		templateURL: templateURL,
 	}, nil

--- a/pkg/fragment/definition.go
+++ b/pkg/fragment/definition.go
@@ -95,9 +95,13 @@ func (d *Definition) Requestable(target *url.URL, pathParams map[string]string, 
 
 	request.RawQuery = query.Encode()
 
+	templateURL := *target
+	templateURL.Path = strings.Join(d.routeParts, "/")
+
 	return &Request{
-		RequestURL: &request,
-		Definition: d,
+		RequestURL:  &request,
+		Definition:  d,
+		templateURL: &templateURL,
 	}, nil
 }
 
@@ -115,11 +119,13 @@ func (d *Definition) PreloadUrl(target string) {
 }
 
 type Request struct {
-	RequestURL *url.URL
-	Definition *Definition
+	RequestURL  *url.URL
+	Definition  *Definition
+	templateURL *url.URL
 }
 
 var _ multiplexer.Requestable = &Request{}
 
 func (fr *Request) URL() string                 { return fr.RequestURL.String() }
+func (fr *Request) TemplateURL() string         { return fr.templateURL.String() }
 func (fr *Request) Metadata() map[string]string { return fr.Definition.Metadata }

--- a/pkg/fragment/definition_test.go
+++ b/pkg/fragment/definition_test.go
@@ -19,6 +19,7 @@ func TestFragment_IntoRequestable(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "http://fake.net/hello/fox.mulder", requestable.URL())
+	require.Equal(t, "http://fake.net/hello/:name", requestable.TemplateURL())
 }
 
 func TestFragment_IntoRequestable_MissingDynamicPart(t *testing.T) {
@@ -41,4 +42,5 @@ func TestFragment_IntoRequestable_HandlesURLEncodings(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, "http://fake.net/hello/mulder%2fscully", requestable.URL())
+	require.Equal(t, "http://fake.net/hello/:name", requestable.TemplateURL())
 }

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -20,6 +20,7 @@ type fakeRequestable struct {
 }
 
 func (ff *fakeRequestable) URL() string                 { return ff.url }
+func (ff *fakeRequestable) TemplateURL() string         { return ff.url }
 func (ff *fakeRequestable) Metadata() map[string]string { return make(map[string]string) }
 func newFakeRequestable(url string) *fakeRequestable    { return &fakeRequestable{url: url} }
 

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -98,7 +98,7 @@ func TestResultErrorMessagesFilterUrls(t *testing.T) {
 
 	r := newRequest()
 	req := newFakeRequestable("http://localhost:9990/wowomg?foo=bar")
-	req.templateURL = "http://localhost:9990/:name?foo=bar"
+	req.templateURL = "http://localhost:9990/:name"
 	r.WithRequestable(req)
 	r.Timeout = defaultTimeout
 	_, err := r.Do(context.TODO())

--- a/pkg/multiplexer/requestable.go
+++ b/pkg/multiplexer/requestable.go
@@ -6,6 +6,7 @@ type RequestableContextKey struct{}
 
 type Requestable interface {
 	URL() string
+	TemplateURL() string
 	Metadata() map[string]string
 }
 

--- a/pkg/multiplexer/result.go
+++ b/pkg/multiplexer/result.go
@@ -17,8 +17,8 @@ type Results interface {
 	Results() []*Result
 }
 
-func newResultError(req *Request, res *Result) *ResultError {
-	safeUrl := req.SecretFilter.FilterURLString(res.Url)
+func newResultError(errURL string, req *Request, res *Result) *ResultError {
+	safeUrl := req.SecretFilter.FilterURLString(errURL)
 	msg := fmt.Sprintf("status: %d url: %s", res.StatusCode, safeUrl)
 
 	return &ResultError{Result: res, msg: msg}

--- a/pkg/multiplexer/result.go
+++ b/pkg/multiplexer/result.go
@@ -18,7 +18,7 @@ type Results interface {
 }
 
 func newResultError(errURL string, req *Request, res *Result) *ResultError {
-	safeUrl := req.SecretFilter.FilterURLString(errURL)
+	safeUrl := req.SecretFilter.FilterURLStringThrough(res.Url, errURL)
 	msg := fmt.Sprintf("status: %d url: %s", res.StatusCode, safeUrl)
 
 	return &ResultError{Result: res, msg: msg}

--- a/pkg/secretfilter/secretfilter.go
+++ b/pkg/secretfilter/secretfilter.go
@@ -10,6 +10,7 @@ type Filter interface {
 	IsAllowed(string) bool
 	FilterURL(url *url.URL) *url.URL
 	FilterURLString(url string) string
+	FilterURLStringThrough(source string, target string) string
 	FilterQueryParams(params url.Values) url.Values
 	FilterURLError(errURL string, err *url.Error) *url.Error
 }
@@ -77,10 +78,24 @@ func (l *secretFilter) FilterQueryParams(query url.Values) url.Values {
 	return filteredQueryParams
 }
 
+func (l *secretFilter) FilterURLStringThrough(source string, target string) string {
+	// Copy query params from source to target
+	parsedSource, parseErr := url.Parse(source)
+	if parseErr == nil {
+		parsedTarget, parseErr := url.Parse(target)
+		if parseErr == nil {
+			parsedTarget.RawQuery = parsedSource.RawQuery
+			target = parsedTarget.String()
+		}
+	}
+
+	return l.FilterURLString(target)
+}
+
 func (l *secretFilter) FilterURLError(errURL string, err *url.Error) *url.Error {
 	return &url.Error{
 		Op:  err.Op,
-		URL: l.FilterURLString(errURL),
+		URL: l.FilterURLStringThrough(err.URL, errURL),
 		Err: err.Err,
 	}
 }

--- a/pkg/secretfilter/secretfilter.go
+++ b/pkg/secretfilter/secretfilter.go
@@ -11,7 +11,7 @@ type Filter interface {
 	FilterURL(url *url.URL) *url.URL
 	FilterURLString(url string) string
 	FilterQueryParams(params url.Values) url.Values
-	FilterURLError(err *url.Error) *url.Error
+	FilterURLError(errURL string, err *url.Error) *url.Error
 }
 
 type mapKey struct{}
@@ -77,10 +77,10 @@ func (l *secretFilter) FilterQueryParams(query url.Values) url.Values {
 	return filteredQueryParams
 }
 
-func (l *secretFilter) FilterURLError(err *url.Error) *url.Error {
+func (l *secretFilter) FilterURLError(errURL string, err *url.Error) *url.Error {
 	return &url.Error{
 		Op:  err.Op,
-		URL: l.FilterURLString(err.URL),
+		URL: l.FilterURLString(errURL),
 		Err: err.Err,
 	}
 }

--- a/pkg/secretfilter/secretfilter_test.go
+++ b/pkg/secretfilter/secretfilter_test.go
@@ -113,9 +113,9 @@ func TestSecretFilter_FilterUrlError(t *testing.T) {
 	}
 
 	filter := New()
-	filtered := filter.FilterURLError(original)
+	filtered := filter.FilterURLError("http://localhost/:foo", original)
 
-	require.Equal(t, "http://localhost/foo?a=FILTERED", filtered.URL)
+	require.Equal(t, "http://localhost/:foo", filtered.URL)
 	require.Equal(t, "Get", filtered.Op)
 	require.Equal(t, io.EOF, filtered.Err)
 }

--- a/pkg/secretfilter/secretfilter_test.go
+++ b/pkg/secretfilter/secretfilter_test.go
@@ -115,7 +115,7 @@ func TestSecretFilter_FilterUrlError(t *testing.T) {
 	filter := New()
 	filtered := filter.FilterURLError("http://localhost/:foo", original)
 
-	require.Equal(t, "http://localhost/:foo", filtered.URL)
+	require.Equal(t, "http://localhost/:foo?a=FILTERED", filtered.URL)
 	require.Equal(t, "Get", filtered.Op)
 	require.Equal(t, io.EOF, filtered.Err)
 }


### PR DESCRIPTION
This pull request uses the template fragment definition URL as the one surfaced in errors passed through the secret filter.

This ensures definitions such as `/route/:user/:status` will not surface the replaced values such as `/route/kevin/friday` in result/url errors.

This makes it consistent with the old behavior where `/route?user=kevin&status=friday` was surfaced as `/route?user=FILTERED&status=FILTERED`.

