### PR TITLE
Remove legacy route support

### DIFF
--- a/route.go
+++ b/route.go
@@ -68,11 +68,6 @@ func newRoute(path string, metadata map[string]string, root *fragment.Definition
 
 // Validates if the route and fragments have compatible dynamic route parts.
 func (r *Route) Validate() error {
-	// Legacy routes skip validation
-	if r.Metadata["legacy"] == "true" {
-		return nil
-	}
-
 	for _, fragment := range r.FragmentsToRequest() {
 		if !fragment.IgnoreValidation && !compareStringSlice(r.dynamicParts, fragment.DynamicParts()) {
 			return &RouteValidationError{Route: r, Fragment: fragment}

--- a/server.go
+++ b/server.go
@@ -267,13 +267,6 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request, route *Ro
 	for _, f := range route.FragmentsToRequest() {
 		query := url.Values{}
 
-		// support legacy behavior of passing query parameters
-		if f.Metadata["legacy"] == "true" {
-			for name, value := range parameters {
-				query.Add(name, value)
-			}
-		}
-
 		for name, values := range r.URL.Query() {
 			if query.Get(name) == "" {
 				for _, value := range values {


### PR DESCRIPTION
This removes support for legacy routes that relied on the query
parameter logic instead of named parameters.
