### PR TITLE
Re-use parent span's sample rate

### DIFF
--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -69,7 +69,6 @@ func Instrument(config TracingConfig, l logger) (func(), error) {
 		tracerProvider := sdktrace.NewTracerProvider(
 			sdktrace.WithResource(resource),
 			sdktrace.WithSpanProcessor(batchSpanProcessor),
-			sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		)
 
 		//TODO use structured logging


### PR DESCRIPTION
This removes the option that told otel to always sample in favor of
re-using the sampling from the parent span.
