### PR TITLE
Re-use existing trace when possible

### DIFF
--- a/server.go
+++ b/server.go
@@ -197,11 +197,10 @@ func (s *Server) Close() {
 
 // TODO this should probably be a tree structure for faster lookups
 func (s *Server) MatchingRoute(path string) (*Route, map[string]string) {
-	parts := strings.Split(path, "/")
-
-	if s.IgnoreTrailingSlash && parts[len(parts)-1] == "" {
-		parts = parts[:len(parts)-1]
+	if s.IgnoreTrailingSlash && path != "/" {
+		path = strings.TrimRight(path, "/")
 	}
+	parts := strings.Split(path, "/")
 
 	for _, route := range s.routes {
 		if route.matchParts(parts) {

--- a/server.go
+++ b/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/blakewilliams/viewproxy/pkg/multiplexer"
 	"github.com/blakewilliams/viewproxy/pkg/secretfilter"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -215,6 +216,7 @@ func (s *Server) MatchingRoute(path string) (*Route, map[string]string) {
 func (s *Server) rootHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		ctx = otel.GetTextMapPropagator().Extract(ctx, propagation.HeaderCarrier(r.Header))
 
 		tracer := otel.Tracer("server")
 		var span trace.Span

--- a/server_test.go
+++ b/server_test.go
@@ -73,6 +73,33 @@ func TestServer(t *testing.T) {
 	require.Equal(t, "<html><body>hello world</body></html>", string(body))
 }
 
+func TestServerRoot(t *testing.T) {
+	instance := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte("Internal server error"))
+	})
+	testServer := httptest.NewServer(instance)
+
+	viewProxyServer := newServer(t, testServer.URL)
+	viewProxyServer.Addr = "localhost:9997"
+	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
+
+	root := fragment.Define("/")
+
+	err := viewProxyServer.Get("/", root)
+	require.NoError(t, err)
+	viewProxyServer.Logger = log.New(os.Stdout, "", log.Ldate|log.Ltime)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	viewProxyServer.CreateHandler().ServeHTTP(w, r)
+
+	resp := w.Result()
+
+	require.Equal(t, 500, resp.StatusCode)
+}
+
 func TestQueryParamForwardingServer(t *testing.T) {
 	viewProxyServer := newServer(t, targetServer.URL)
 	viewProxyServer.Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)


### PR DESCRIPTION
As-is viewproxy always creates a new trace even if it was passed the headers indicating that it should continue an existing trace.

This adds support for continuing and existing trace by using the TextMapPropagator's `Extract` method on the request headers.
