### PR TITLE
Don't treat tracing errors as fatal

### DIFF
--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -86,7 +86,7 @@ func Instrument(config TracingConfig, l logger) (func(), error) {
 		return func() {
 			err := tracerProvider.Shutdown(ctx)
 			if err != nil {
-				l.Fatalln("failed to stop tracer", err)
+				l.Println("failed to stop tracer", err)
 			}
 		}, nil
 	}
@@ -102,6 +102,6 @@ type ErrorHandler struct {
 
 func (eh ErrorHandler) Handle(err error) {
 	if err != nil {
-		eh.logger.Fatalln("encountered a problem during tracing", err)
+		eh.logger.Println("encountered a problem during tracing", err)
 	}
 }


### PR DESCRIPTION
This pull request changes the tracing error handling to log them via `Println`, instead of `Fatalln`.

Logging interface implementations may call `exit` on fatal errors and tracing errors don't feel like they rise to that level of seriousness and can just be logged less severly.