### PR TITLE
Don't overwrite context variable in request loop

### DIFF
--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -83,11 +83,11 @@ func (r *Request) Do(ctx context.Context) ([]*Result, error) {
 	ctx, cancel := context.WithTimeout(ctx, r.Timeout)
 	defer cancel()
 
-	wg := sync.WaitGroup{}
 	reqCount := len(r.requestables)
+	wg := sync.WaitGroup{}
+	wg.Add(reqCount)
 	errCh := make(chan error, reqCount)
 	results := make([]*Result, reqCount)
-	wg.Add(reqCount)
 
 	for i, f := range r.requestables {
 		reqCtx := context.WithValue(ctx, RequestableContextKey{}, f)

--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -87,10 +87,10 @@ func (r *Request) Do(ctx context.Context) ([]*Result, error) {
 	reqCount := len(r.requestables)
 	errCh := make(chan error, reqCount)
 	results := make([]*Result, reqCount)
+	wg.Add(reqCount)
 
 	for i, f := range r.requestables {
-		wg.Add(1)
-		ctx = context.WithValue(ctx, RequestableContextKey{}, f)
+		reqCtx := context.WithValue(ctx, RequestableContextKey{}, f)
 
 		go func(ctx context.Context, requestable Requestable, i int, wg *sync.WaitGroup) {
 			defer wg.Done()
@@ -116,7 +116,7 @@ func (r *Request) Do(ctx context.Context) ([]*Result, error) {
 			}
 
 			results[i] = result
-		}(ctx, f, i, &wg)
+		}(reqCtx, f, i, &wg)
 	}
 
 	// wait for all responses to complete


### PR DESCRIPTION
I noticed we were overwriting the root level context variable in the requestable loop for the context we eventually wait on after starting the go routines:

https://github.com/BlakeWilliams/viewproxy/blob/d4540cae717b7a3101be386179585d5b0440ab32/pkg/multiplexer/multiplexer.go#L135-L136

It seemed best not to overwrite this value with request specific state and they wait on the done channel for the final request value.

I don't have any evidence this is causing any issues but just noticed it while reviewing the multiplexer code.