### PR TITLE
Detect request cancellations and return new error type

### DIFF
--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -166,6 +166,7 @@ func TestFetchTimeout(t *testing.T) {
 
 func TestFetchCancelled(t *testing.T) {
 	server := startServer(t)
+	defer server.Close()
 
 	r := newRequest()
 	r.WithRequestable(newFakeRequestable("http://localhost:9990?fragment=slow"))
@@ -176,8 +177,6 @@ func TestFetchCancelled(t *testing.T) {
 	_, err := r.Do(ctx)
 
 	require.EqualError(t, err, "multiplexer request was canceled: context canceled")
-
-	server.Close()
 }
 
 func TestCanIgnoreNon2xxErrors(t *testing.T) {

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -164,6 +164,22 @@ func TestFetchTimeout(t *testing.T) {
 	server.Close()
 }
 
+func TestFetchCancelled(t *testing.T) {
+	server := startServer(t)
+
+	r := newRequest()
+	r.WithRequestable(newFakeRequestable("http://localhost:9990?fragment=slow"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := r.Do(ctx)
+
+	require.EqualError(t, err, "multiplexer request was canceled: context canceled")
+
+	server.Close()
+}
+
 func TestCanIgnoreNon2xxErrors(t *testing.T) {
 	server := startServer(t)
 


### PR DESCRIPTION
If a request is canceled by the client, a timeout error is not appropriate because the server may be unable to write a response.

Returning a cancellation error will allow the server to ignore the requests